### PR TITLE
check mapred return value for correctness

### DIFF
--- a/examples/riakc_mr.config
+++ b/examples/riakc_mr.config
@@ -19,15 +19,17 @@
 %% {operations, [{put, 1}]}.
 %% {key_generator, {int_to_str, {sequential_int, 10000}}}.
 %% {value_generator,
-%%  {function, basho_bench_driver_riakc_pb, mapred_valgen, [10000]}}.
+%%  {function, basho_bench_driver_riakc_pb, mapred_ordered_valgen, []}}.
 
 %% test
+
+%% for computing expected bucket sum
+{riakc_pb_preloaded_keys, 10000}.
 
 {mode, max}.
 {duration, 1}.
 {concurrent, 1}.
-{operations, [{mr_keylist_js, 1}]}.
+{operations, [{mr_bucket_js, 1}]}.
 {key_generator, {int_to_str, {uniform_int, 9999}}}.
 {value_generator, {fixed_bin, 1}}.
 {riakc_pb_keylist_length, 1000}.
-


### PR DESCRIPTION
This is related to testing AZ561.  I had to change the value generator to produce a predictable value, and I also had to add another config setting to be able to compute whole-bucket results without listing the bucket first.
