### PR TITLE
Support "put" in HTTP Raw driver

### DIFF
--- a/src/basho_bench_driver_http_raw.erl
+++ b/src/basho_bench_driver_http_raw.erl
@@ -183,7 +183,14 @@ run(insert, KeyGen, ValueGen, State) ->
             {error, Reason, S2}
     end;
 run(put, KeyGen, ValueGen, State) ->
-    run(insert, KeyGen, ValueGen, State);
+    {NextUrl, S2} = next_url(State),
+    Url = url(NextUrl, KeyGen, State#state.path_params),
+    case do_put(Url, [State#state.client_id], ValueGen) of
+        ok ->
+            {ok, S2};
+        {error, Reason} ->
+            {error, Reason, S2}
+    end;
 
 run(search, _KeyGen, _ValueGen, State) when State#state.searchgen == undefined ->
     {_NextUrl, S2} = next_url(State),


### PR DESCRIPTION
Before only insert was supported while put is the verb used.

Now both insert and put is supported, where insert does a POST and lets Riak generate the key, while put uses the keygen.
