### PR TITLE
Change default value of riakc_pb_replies = quorum

### DIFF
--- a/src/basho_bench_driver_riakc_pb.erl
+++ b/src/basho_bench_driver_riakc_pb.erl
@@ -60,7 +60,7 @@ new(Id) ->
     Port  = basho_bench_config:get(riakc_pb_port, 8087),
     %% riakc_pb_replies sets defaults for R, W, DW and RW.
     %% Each can be overridden separately
-    Replies = basho_bench_config:get(riakc_pb_replies, 2),
+    Replies = basho_bench_config:get(riakc_pb_replies, quorum),
     R = basho_bench_config:get(riakc_pb_r, Replies),
     W = basho_bench_config:get(riakc_pb_w, Replies),
     DW = basho_bench_config:get(riakc_pb_dw, Replies),


### PR DESCRIPTION
To avoid unwanted surprise when testing with buckets
with n_val /= 3, it's much more helpful to use quorum
instead of 2.  For example, working on buckets with
n_val = 1 will result in zillions of
{error, {n_val_violation, 1}} errors.  For buckets
with larger n_val, e.g. n_val = 17, this plugin
will report much higher performance than you expect.
