### PR TITLE
Fixed installation of R packages

### DIFF
--- a/priv/common.r
+++ b/priv/common.r
@@ -1,11 +1,12 @@
 # Load all the necessary packages, installing missing ones when necessary
 packages.to.install <- c("plyr", "grid", "getopt", "proto", "ggplot2")
 
-for(p in packages.to.install){
+for(p in packages.to.install)
+  {
         print(p)
         if (suppressWarnings(!require(p, character.only = TRUE))) install.packages(p, repos = "http://lib.stat.cmu.edu/R/CRAN")
         if (p == "ggplot2") suppressWarnings(library(ggplot2))
-}
+  }
 
 # Load a latency file and ensure that it is appropriately tagged
 load_latency_frame <- function(File)


### PR DESCRIPTION
User no longer needs to run 'make results' twice in order to get the necessary R libraries installed if they don't already have them.
