### PR TITLE
Changed ibrowse dep to @dizzyd's version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {deps,
  [
   {basho_stats, ".*", {git, "git://github.com/basho/basho_stats.git", "HEAD"}},
-  {ibrowse, ".*", {git, "git://github.com/cmullaparthi/ibrowse.git", "HEAD"}},
+  {ibrowse, ".*", {git, "git://github.com/dizzyd/ibrowse.git", "HEAD"}},
   {casbench, "0.1", {git, "git://github.com/basho/casbench", "HEAD"}},
   {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", "HEAD"}}
  ]}.


### PR DESCRIPTION
The ibrowse dep's API has changed breaking the httpraw driver. Pointed at @dizzyd's repo instead.
