### PR TITLE
Fix url incompatibility with ibrowse

### DIFF
--- a/src/basho_bench_driver_http_raw.erl
+++ b/src/basho_bench_driver_http_raw.erl
@@ -26,7 +26,7 @@
 
 -include("basho_bench.hrl").
 
--record(url, {abspath, host, port, username, password, path, protocol}).
+-record(url, {abspath, host, port, username, password, path, protocol, host_type}).
 
 -record(state, { client_id,          % Tuple client ID for HTTP requests
                  base_urls,          % Tuple of #url -- one for each IP


### PR DESCRIPTION
ibrowse has added an 8th field in its url record (include/ibrowse.hrl) what broke basho_bench http driver, I just added this field (host_type).
