### PR TITLE
Plain http requests

### DIFF
--- a/src/basho_bench_driver_http_raw.erl
+++ b/src/basho_bench_driver_http_raw.erl
@@ -111,8 +111,8 @@ run(stat, _, _, State) ->
             {error, Reason, S2}
     end;
 
-run(plain_get, _KeyGen, _ValueGen, State) ->
-    Keygen(),
+run(plain_get, KeyGen, _ValueGen, State) ->
+    KeyGen(),
     {NextUrl, S2} = next_url(State),
     case do_get(url(NextUrl, State#state.path_params), State#state.get_headers) of
         {not_found, _Url} ->


### PR DESCRIPTION
Our We decided to use basho_bench for testing plain http service. So this patch implements a method for http_raw driver which just repeatedly fetches the URL. Additionally we rely on some headers so they can be specified in the config too.
