### PR TITLE
Deprecate the int_to_bin key generator, add 2 others to replace it

### DIFF
--- a/src/basho_bench_keygen.erl
+++ b/src/basho_bench_keygen.erl
@@ -34,8 +34,17 @@
 %% API
 %% ====================================================================
 new({int_to_bin, InputGen}, Id) ->
+    ?WARN("The int_to_bin key generator wrapper is deprecated, please use the "
+          "int_to_bin_bigendian or int_to_bin_littleendian wrapper instead\n",
+          []),
     Gen = new(InputGen, Id),
     fun() -> <<(Gen()):32/native>> end;
+new({int_to_bin_bigendian, InputGen}, Id) ->
+    Gen = new(InputGen, Id),
+    fun() -> <<(Gen()):32/big>> end;
+new({int_to_bin_littleendian, InputGen}, Id) ->
+    Gen = new(InputGen, Id),
+    fun() -> <<(Gen()):32/little>> end;
 new({int_to_str, InputGen}, Id) ->
     Gen = new(InputGen, Id),
     fun() -> integer_to_list(Gen()) end;


### PR DESCRIPTION
The two new key generators that this patch adds are much more explicit about the types of 32-bit keys that they generate.
