### PR TITLE
Add {silent, ...} wrapper around driver run() result to skip stats entry

### DIFF
--- a/src/basho_bench_worker.erl
+++ b/src/basho_bench_worker.erl
@@ -226,8 +226,10 @@ worker_next_op(State) ->
     ElapsedUs = timer:now_diff(now(), Start),
     case Result of
         {Res, DriverState} when Res == ok orelse element(1, Res) == ok ->
-            %% Success
             basho_bench_stats:op_complete(Next, Res, ElapsedUs),
+            {ok, State#state { driver_state = DriverState}};
+
+        {Res, DriverState} when Res == silent orelse element(1, Res) == silent ->
             {ok, State#state { driver_state = DriverState}};
 
         {error, Reason, DriverState} ->


### PR DESCRIPTION
Use case: using basho_bench to run load operations that take more than a few seconds to run.  Such operations should return `silent` or `{silent, term()}` to basho_bench, _and also_ such operations must then perform their own stats updates via `basho_bench_stats:op_complete/3`.
