### PR TITLE
Ability to put files and verify search query

### DIFF
--- a/src/basho_bench_config.erl
+++ b/src/basho_bench_config.erl
@@ -22,6 +22,7 @@
 -module(basho_bench_config).
 
 -export([load/1,
+         normalize_ips/2,
          set/2,
          get/1, get/2]).
 
@@ -40,6 +41,22 @@ load(Files) ->
                   ?FAIL_MSG("Failed to parse config file ~s: ~p\n", [File, Reason])
           end || File <- Files ],
     load_config(lists:append(TermsList)).
+
+%% @doc Normalize the list of IPs and Ports.
+%%
+%% E.g.
+%%
+%% ["127.0.0.1", {"127.0.0.1", 8091}, {"127.0.0.1", [8092,8093]}]
+%%
+%% => [{"127.0.0.1", DefaultPort},
+%%     {"127.0.0.1", 8091},
+%%     {"127.0.0.1", 8092},
+%%     {"127.0.0.1", 8093}]
+normalize_ips(IPs, DefultPort) ->
+    F = fun(Entry, Acc) ->
+                normalize_ip_entry(Entry, Acc, DefultPort)
+        end,
+    lists:foldl(F, [], IPs).
 
 set(Key, Value) ->
     ok = application:set_env(basho_bench, Key, Value).
@@ -73,3 +90,10 @@ load_config([{Key, Value} | Rest]) ->
 load_config([ Other | Rest]) ->
     ?WARN("Ignoring non-tuple config value: ~p\n", [Other]),
     load_config(Rest).
+
+normalize_ip_entry({IP, Ports}, Normalized, _) when is_list(Ports) ->
+    [{IP, Port} || Port <- Ports] ++ Normalized;
+normalize_ip_entry({IP, Port}, Normalized, _) ->
+    [{IP, Port}|Normalized];
+normalize_ip_entry(IP, Normalized, DefaultPort) ->
+    [{IP, DefaultPort}|Normalized].

--- a/src/basho_bench_driver_riakc_pb.erl
+++ b/src/basho_bench_driver_riakc_pb.erl
@@ -74,7 +74,7 @@ new(Id) ->
     warn_bucket_mr_correctness(PreloadedKeys),
 
     %% Choose the target node using our ID as a modulus
-    Targets = expand_ips(Ips, Port),
+    Targets = basho_bench_config:normalize_ips(Ips, Port),
     {TargetIp, TargetPort} = lists:nth((Id rem length(Targets)+1), Targets),
     ?INFO("Using target ~p:~p for worker ~p\n", [TargetIp, TargetPort, Id]),
     case riakc_pb_socket:start_link(TargetIp, TargetPort) of
@@ -223,15 +223,6 @@ run(mr_keylist_js, KeyGen, _ValueGen, State) ->
 %% ====================================================================
 %% Internal functions
 %% ====================================================================
-
-expand_ips(Ips, Port) ->
-    lists:foldl(fun({Ip,Ports}, Acc) when is_list(Ports) ->
-                        Acc ++ lists:map(fun(P) -> {Ip, P} end, Ports);
-                   (T={_,_}, Acc) ->
-                        [T|Acc];
-                   (Ip, Acc) ->
-                        [{Ip,Port}|Acc]
-                end, [], Ips).
 
 mapred(State, Input, Query) ->
     case riakc_pb_socket:mapred(State#state.pid, Input, Query) of


### PR DESCRIPTION
This commit adds 3 pieces of functionality.  Two of them are used by Riak Test's `loaded_upgrade` test.
1. Ability to put files.  By adding `{file_dir, Dir}` the HTTP raw driver will PUT all files in `Dir` (non-recursive) and use the basename of the file as the key.
2. Ability to verify `numFound` during search.
3. Centralize normalization of host and port data used by both HTTP and PB drivers.  This is potentially useful to other drivers but I didn't check.
