### PR TITLE
Add value_generator_blob_file config option to value generator.

### DIFF
--- a/include/basho_bench.hrl
+++ b/include/basho_bench.hrl
@@ -11,3 +11,5 @@
 
 -define(FMT(Str, Args), lists:flatten(io_lib:format(Str, Args))).
 
+-define(VAL_GEN_BLOB_CFG, value_generator_blob_file).
+-define(VAL_GEN_SRC_SIZE, value_generator_source_size).

--- a/src/basho_bench_valgen.erl
+++ b/src/basho_bench_valgen.erl
@@ -67,29 +67,29 @@ dimension(_Other, _) ->
 %% ====================================================================
 
 init_source(Id) ->
-    init_source(Id, basho_bench_config:get(value_generator_blob_file, undefined)).
+    init_source(Id, basho_bench_config:get(?VAL_GEN_BLOB_CFG, undefined)).
 
 init_source(Id, undefined) ->
     if Id == 1 -> ?DEBUG("random source\n", []);
        true    -> ok
     end,
-    SourceSz = basho_bench_config:get(value_generator_source_size, 1048576),
-    {SourceSz, crypto:rand_bytes(SourceSz)};
+    SourceSz = basho_bench_config:get(?VAL_GEN_SRC_SIZE, 1048576),
+    {?VAL_GEN_SRC_SIZE, SourceSz, crypto:rand_bytes(SourceSz)};
 init_source(Id, Path) ->
     {Path, {ok, Bin}} = {Path, file:read_file(Path)},
     if Id == 1 -> ?DEBUG("path source ~p ~p\n", [size(Bin), Path]);
        true    -> ok
     end,
-    {size(Bin), Bin}.
+    {?VAL_GEN_BLOB_CFG, size(Bin), Bin}.
 
-data_block({SourceSz, Source}, BlockSize) ->
+data_block({SourceCfg, SourceSz, Source}, BlockSize) ->
     case SourceSz - BlockSize > 0 of
         true ->
             Offset = random:uniform(SourceSz - BlockSize),
             <<_:Offset/bytes, Slice:BlockSize/bytes, _Rest/binary>> = Source,
             Slice;
         false ->
-            ?WARN("value_generator_source_size is too small; it needs a value > ~p.\n",
-                  [BlockSize]),
+            ?WARN("~p is too small ~p < ~p\n",
+                  [SourceCfg, SourceSz, BlockSize]),
             Source
     end.


### PR DESCRIPTION
If present, e.g.,

```
{value_generator_blob_file, "/path/to/a/file"}.
```

... then the value generator will use the contents of that file instead
of the (mostly) completely random bytes that are generated by
`crypto:rand_bytes/1`.  By allowing the specify an arbitrary file,
the user has control over much entropy is present in the values that
basho_bench generates.  The user can specify a file with a single
repeating byte (which would yield the same values that the basho_bench
value generator `{fixed_char, Size}` will yield, or specify a file
that contains app-specific data such as representative JSON samples,
or a file that contains output from a command like `dd if=/dev/urandom`,
which would yield an extremely low amount of entropy similar to
what the basho_bench key generator `{fixed_bin, Size}` yields.

The main reason for adding this kind of user-controllable entropy
for value blobs is to study the compression rates of Riak storage
backends such as ELevelDB.
