### PR TITLE
Add plot scripts which use gnuplot

### DIFF
--- a/priv/gp_latencies.sh
+++ b/priv/gp_latencies.sh
@@ -29,7 +29,7 @@ STATS_KINDS="99th,mean"
 TERMINAL_COMMAND=
 PLOT_STYLE="linespoints pointsize 2 linewidth 1"
 PRE_COMMAD=
-EXEC_COMMAND="gnuplot -p"
+EXEC_COMMAND="gnuplot -persist"
 
 while getopts ":d:o:k:t:s:p:Ph" opt; do
     case $opt in

--- a/priv/gp_throughput.sh
+++ b/priv/gp_throughput.sh
@@ -25,7 +25,7 @@ SUMMARY_KINDS="total,failed"
 TERMINAL_COMMAND=
 PLOT_STYLE="linespoints pointsize 2 linewidth 1"
 PRE_COMMAD=
-EXEC_COMMAND="gnuplot -p"
+EXEC_COMMAND="gnuplot -persist"
 
 while getopts ":d:k:t:s:p:Ph" opt; do
     case $opt in


### PR DESCRIPTION
This pull request adds scripts to plot throuput and latencies from
basho_bench's test result.
Gnuplot is easy to install/use in several environments,
so it is a good complement to R.

Simple usage (after some test run):

```
$ priv/gp_latencies.sh
$ priv/gp_throughput.sh
```

Both scripts accepts `-h` option to print full usage.
