### PR TITLE
Fix Logging, Add Option Handling

### DIFF
--- a/include/basho_bench.hrl
+++ b/include/basho_bench.hrl
@@ -1,5 +1,6 @@
 
 -define(FAIL_MSG(Str, Args), ?ERROR(Str, Args), halt(1)).
+-define(STD_ERR(Str, Args), io:format(standard_error, Str, Args)).
 
 -define(CONSOLE(Str, Args), lager:info(Str, Args)).
 

--- a/rebar.config
+++ b/rebar.config
@@ -23,13 +23,15 @@
   {riakc, ".*",
    {git, "git://github.com/basho/riak-erlang-client", {tag, "1.2.1"}}},
   {mochiweb, "1.5.1",
-   {git, "git://github.com/basho/mochiweb", {tag, "1.5.1-riak-1.0.x-fixes"}}}
+   {git, "git://github.com/basho/mochiweb", {tag, "1.5.1-riak-1.0.x-fixes"}}},
+  {getopt, ".*",
+   {git, "git://github.com/jcomellas/getopt", {tag, "v0.4"}}}
  ]}.
 
 {erl_opts, [{src_dirs, [src]},
            {parse_transform, lager_transform}]}.
 
-{escript_incl_apps, [lager, bear, folsom, ibrowse, riakc, mochiweb, protobuffs ]}.
+{escript_incl_apps, [lager, getopt, bear, folsom, ibrowse, riakc, mochiweb, protobuffs ]}.
 
 %% Uncomment to use the Java client bench driver
 %% {escript_emu_args, "%%! -name bb@127.0.0.1 -setcookie YOUR_ERLANG_COOKIE\n"}.


### PR DESCRIPTION
This commit address an issue and adds a feature

Issue

When the switch to lager was made a bug was introduced where
initialization of basho bench could fail before lager is started.
Specifically, if a malformed config was passed basho bench would exit
with no indication as to why.  This was because the config was read
for `test_dir` to determine where to write the log files but lager
cannot start until the log file locations are determined.  Thus a
chicken-egg problem.  This commit changes that behavior, pulling the
test_dir (now called results_dir) from command line options.

Feature

In order to pass the results_dir as a command line option I thought it
would be best to add proper argument handling in the form of getopt.
In addition to the `-d` option I also added `--bench-name`.  By
default basho bench stores the results of a run under a directory with
the current iso8601 timestamp.  This is a great default but many times
I want to name the results of a run for posterity and this required an
extra copy operation afterwards.  The `-n` option allows you to name a
test run which will also be used as the name of the directory.  By
default basho bench will act as it did before but the `-d` and `-n`
options give you more control on where to store results.

Usage statement:

```
./basho_bench -h
Usage: ./basho_bench [-h] [-d <results_dir>] [-n <bench_name>] CONFIG_FILE

  -h, --help            Print usage
  -d, --results-dir     Base directory to store test results, defaults to ./tests
  -n, --bench-name      Name to identify the run, defaults to timestamp
```
