### PR TITLE
Change filter function to int_to_str and add some examples

### DIFF
--- a/examples/riakc_pb.config
+++ b/examples/riakc_pb.config
@@ -6,7 +6,13 @@
 
 {driver, basho_bench_driver_riakc_pb}.
 
-{key_generator, {int_to_bin, {uniform_int, 10000}}}.
+%% Key generator examples
+%% 1. variable-digit decimal
+{key_generator, {int_to_str, {uniform_int, 10000}}}.
+%% 2. zero-padded 16-digit decimal
+%% {key_generator, {to_binstr, "~16.10.0B", {uniform_int, 10000}}}.
+%% 3. 32bit binary (big-endian)
+%% {key_generator, {int_to_bin_bigendian, {uniform_int, 10000}}}.
 
 {value_generator, {fixed_bin, 10000}}.
 


### PR DESCRIPTION
- Add int_to_str as the first candidate because int_to_bin[_*endian]
  truncates large integer to 32bit
- Add fixed digit example (to_binstr)
