### PR TITLE
Possibility to plot several tests on the same plot

### DIFF
--- a/README.org
+++ b/README.org
@@ -109,13 +109,16 @@ $ ./priv/gp_latency.sh
 
    Some of options for these scripts are:
 
-   - =-d TEST_DIR= : directory which include test result CSV files
+   - =-d TEST_DIR= : comma-separated list of directories which include
+         test result CSV files
    - =-t TERMINAL_TYPE= : gnuplot terminal type
    - =-P= : just print gnuplot script without drawing graph
 
    For example, you can draw graphs with ASCII characters
    by the option =-t dumb=, which is useful in non-graphical
    environment or quick sharing of result in chat.
+
+   Also, you can plot multiple test runs on a single plot by using "-d" switch.
 
 ** Contributing
    We encourage contributions to Basho Bench from the community.

--- a/priv/gp_latencies.sh
+++ b/priv/gp_latencies.sh
@@ -60,24 +60,27 @@ done
 
 function plot_command(){
     echo "plot \\"
-    if [ -z "${OPERATIONS}" ]; then
-        for f in `ls ${TEST_DIR}/*_latencies.csv`
-        do
-            OPERATION=`basename $f _latencies.csv`
-            plot_per_op ${OPERATION}
-        done
-    else
-        for OPERATION in ${OPERATIONS//,/ }
-        do
-            plot_per_op ${OPERATION}
-        done
-    fi
+    for THIS_TEST_DIR in ${TEST_DIR//,/ }
+    do
+        if [ -z "${OPERATIONS}" ]; then
+            for f in `ls ${THIS_TEST_DIR}/*_latencies.csv`
+            do
+                OPERATION=`basename $f _latencies.csv`
+                plot_per_op ${OPERATION}
+            done
+        else
+            for OPERATION in ${OPERATIONS//,/ }
+            do
+                plot_per_op ${OPERATION}
+            done
+        fi
+    done
     echo "    1/0 notitle # dummy"
 }
 
 function plot_per_op(){
     OPERATION=$1
-    LATENCY_FILE="${TEST_DIR}/${OPERATION}_latencies.csv"
+    LATENCY_FILE="${THIS_TEST_DIR}/${OPERATION}_latencies.csv"
     for KIND in ${STATS_KINDS//,/ }
     do
         plot_per_op_kind ${OPERATION} ${LATENCY_FILE} ${KIND}
@@ -99,7 +102,12 @@ function plot_per_op_kind() {
     esac
     echo "    \"${FILE}\" using 1:(\$${COL_POS}/\$2/1000) with \\"
     echo "        ${PLOT_STYLE} \\"
-    echo "        title \"${OPERATION}:${KIND}\" \\"
+    # If plotting only 1 directory, do not add its name
+    if [ "${TEST_DIR}" == "${THIS_TEST_DIR}" ]; then
+        echo "        title \"${OPERATION}:${KIND}\" \\"
+    else
+        echo "        title \"${THIS_TEST_DIR##*/} - ${OPERATION}:${KIND}\" \\"
+    fi
     echo "        ,\\"
 }
 

--- a/priv/gp_throughput.sh
+++ b/priv/gp_throughput.sh
@@ -5,7 +5,7 @@ function Usage {
   echo "                        [-t TERMINAL_TYPE] [-s PLOT_STYLE] [-p PRE_COMMAD]" >&2
   echo "                        [-P] [-h]" >&2
   echo "" >&2
-  echo "    -d TEST_DIR:      test directory with summary.csv" >&2
+  echo "    -d TEST_DIR:      comma-separaated test directories with summary.csv" >&2
   echo "                      default: \"tests/current\"" >&2
   echo "    -k SUMMARY_KINDS: summary kinds in comma separated list" >&2
   echo "                      default: \"total,failed\"" >&2
@@ -54,15 +54,18 @@ done
 
 function plot_command(){
     echo "plot \\"
-    for KIND in ${SUMMARY_KINDS//,/ }
+    for THIS_TEST_DIR in ${TEST_DIR//,/ }
     do
-        plot_per_kind ${KIND}
+        for KIND in ${SUMMARY_KINDS//,/ }
+        do
+            plot_per_kind ${KIND}
+        done
     done
     echo "    1/0 notitle # dummy"
 }
 
 function plot_per_kind() {
-    FILE=${TEST_DIR}/summary.csv
+    FILE=${THIS_TEST_DIR}/summary.csv
     case "${KIND}" in
         "total")      COL_POS=3 ;;
         "successful") COL_POS=4 ;;
@@ -71,7 +74,13 @@ function plot_per_kind() {
     esac
     echo "    \"${FILE}\" using 1:(\$${COL_POS}/\$2) with \\"
     echo "        ${PLOT_STYLE} \\"
-    echo "        title \"${KIND}\" \\"
+
+    # If plotting only 1 directory, do not add its name
+    if [ "${THIS_DIR}" == "${THIS_TEST_DIR}" ]; then
+        echo "        title \"${KIND}\" \\"
+    else
+        echo "        title \"${THIS_TEST_DIR##*/} - ${KIND}\" \\"
+    fi
     echo "        ,\\"
 }
 


### PR DESCRIPTION
This allows comparing benchmarks with each other. For example, it is
very convenient to visualise on the same graph how throughput changes
when {concurrent, N} changes.

For example, here is a Sphinx search engine throughput for my specific query for binary (light_bin_X) and SphinxQL (light_ql_X) protocols with X parallel workers:
![multi_gp_example](https://f.cloud.github.com/assets/107720/187676/59d8ccee-7d7e-11e2-8e71-611c3ba20295.png)

Easy to construct:

```
 priv/gp_throughput.sh -k total -d tests/light_ql_1,tests/light_ql_2,tests/light_bin_1,tests/light_bin_2
```
