### PR TITLE
Updated http_raw driver to allow appending custom headers.

### DIFF
--- a/examples/httpraw.config
+++ b/examples/httpraw.config
@@ -6,6 +6,10 @@
 
 {driver, basho_bench_driver_http_raw}.
 
+%% Example custom headers.  Beware using headers that may cause collisions
+%% with automatically generated headers used by other parts of the driver.
+%% {http_raw_append_headers, [{"Authorization", "Basic dXNlcm5hbWU6cGFzc3dvcmQ="}]}.
+
 %% Example syntax (mykeygen_seq is not defined)
 %% {key_generator, {function, test, mykeygen_seq, [10000, 10, 10, 100]}}.
 

--- a/src/basho_bench_driver_http_raw.erl
+++ b/src/basho_bench_driver_http_raw.erl
@@ -471,7 +471,7 @@ send_request(Url, Headers, Method, Body, Options, Count) ->
                    SSLOpts when is_list(SSLOpts) ->
                        [{is_ssl, true}, {ssl_options, SSLOpts} | Options]
                end,
-    case catch(ibrowse_http_client:send_req(Pid, Url, Headers, Method, Body, Options2, basho_bench_config:get(http_raw_request_timeout, 5000))) of
+    case catch(ibrowse_http_client:send_req(Pid, Url, Headers ++ basho_bench_config:get(http_raw_append_headers,[]), Method, Body, Options2, basho_bench_config:get(http_raw_request_timeout, 5000))) of
         {ok, Status, RespHeaders, RespBody} ->
             maybe_disconnect(Url),
             {ok, Status, RespHeaders, RespBody};


### PR DESCRIPTION
You can now set additional headers for each http request by using:

`{http_raw_append_headers, [{"Authorization", "Basic dXNlcm5hbWU6cGFzc3dvcmQ="}]}.`

in the `httpraw.config` file.
