### PR TITLE
Added support for 2i queries and MR emulated multigets

### DIFF
--- a/examples/riakc_pb_2i.config
+++ b/examples/riakc_pb_2i.config
@@ -8,16 +8,16 @@
 
 {duration, 1}.
 
-{concurrent, 2}.
+{concurrent, 1}.
 
 {driver, basho_bench_driver_riakc_pb}.
 
-{key_generator, {int_to_str, {uniform_int, 10000}}}.
+{key_generator, {to_binstr, "~p", {uniform_int, 10000}}}.
 
-{value_generator, {fixed_bin, 10000}}.
+{value_generator, {fixed_bin, 1000}}.
 
 {riakc_pb_ips, [{127,0,0,1}]}.
 
-{operations, [{update,3},{get,3},{{get_index,"intindex",5},1},{{get_index,"binindex",5},1},{{mr_multiget,5},1},{{mr_multiget,10},1}]}.
+{operations, [{update,1},{get,1},{{get_index,"intindex",5},1},{{get_index,"intindex",5, 10},1},{{get_index,"binindex",5},1},{{get_index,"binindex",5,10},1}]}.
 
 {secondary_indexes, [{"intindex",integer_index,1,100},{"binindex",binary_index,1,100}]}.

--- a/examples/riakc_pb_2i.config
+++ b/examples/riakc_pb_2i.config
@@ -1,0 +1,23 @@
+% This file contains an example of a job simulating secondary index queries
+% and multi-GET queries emulated through MapReduce. 
+% The MapReduce multiget operation assumes that all keys in the keyspace
+% does exist at the start, and requiresconfig file riakc_pb_2i_preload.config 
+% to be run first.
+% This test requires LevelDB backend to work.
+{mode, max}.
+
+{duration, 1}.
+
+{concurrent, 2}.
+
+{driver, basho_bench_driver_riakc_pb}.
+
+{key_generator, {int_to_str, {uniform_int, 10000}}}.
+
+{value_generator, {fixed_bin, 10000}}.
+
+{riakc_pb_ips, [{127,0,0,1}]}.
+
+{operations, [{update,3},{get,3},{{get_index,"intindex",5},1},{{get_index,"binindex",5},1},{{mr_multiget,5},1},{{mr_multiget,10},1}]}.
+
+{secondary_indexes, [{"intindex",integer_index,1,100},{"binindex",binary_index,1,100}]}.

--- a/examples/riakc_pb_2i_preload.config
+++ b/examples/riakc_pb_2i_preload.config
@@ -4,13 +4,13 @@
 
 {duration, 10}.
 
-{concurrent, 1}.
+{concurrent, 2}.
 
 {driver, basho_bench_driver_riakc_pb}.
 
-{key_generator, {int_to_str, {sequential_int, 10000}}}.
+{key_generator, {to_binstr, "~p", {partitioned_sequential_int, 10000}}}.
 
-{value_generator, {fixed_bin, 10000}}.
+{value_generator, {fixed_bin, 1000}}.
 
 {riakc_pb_ips, [{127,0,0,1}]}.
 

--- a/examples/riakc_pb_2i_preload.config
+++ b/examples/riakc_pb_2i_preload.config
@@ -1,0 +1,20 @@
+% This configuration file pre-loads records that are required in order
+% to run riakc_pb_21.config successfully.
+{mode, max}.
+
+{duration, 10}.
+
+{concurrent, 1}.
+
+{driver, basho_bench_driver_riakc_pb}.
+
+{key_generator, {int_to_str, {sequential_int, 10000}}}.
+
+{value_generator, {fixed_bin, 10000}}.
+
+{riakc_pb_ips, [{127,0,0,1}]}.
+
+{operations, [{put,1}]}.
+
+% Add 2 secondary indexes to each object, one integer index and one binary index
+{secondary_indexes, [{"intindex",integer_index,1,100},{"binindex",binary_index,1,100}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -21,7 +21,7 @@
    {git, "git://github.com/ostinelli/erlcassa.git",
    {branch, "master"}}},
   {riakc, ".*",
-   {git, "git://github.com/basho/riak-erlang-client", {tag, "1.2.1"}}},
+   {git, "git://github.com/basho/riak-erlang-client", {tag, "1.3.3"}}},
   {mochiweb, "1.5.1",
    {git, "git://github.com/basho/mochiweb", {tag, "1.5.1-riak-1.0.x-fixes"}}},
   {getopt, ".*",
@@ -31,7 +31,7 @@
 {erl_opts, [{src_dirs, [src]},
            {parse_transform, lager_transform}]}.
 
-{escript_incl_apps, [lager, getopt, bear, folsom, ibrowse, riakc, mochiweb, protobuffs ]}.
+{escript_incl_apps, [lager, getopt, bear, folsom, ibrowse, riakc, mochiweb, riak_pb, protobuffs ]}.
 
 %% Uncomment to use the Java client bench driver
 %% {escript_emu_args, "%%! -name bb@127.0.0.1 -setcookie YOUR_ERLANG_COOKIE\n"}.

--- a/rebar.config
+++ b/rebar.config
@@ -21,7 +21,7 @@
    {git, "git://github.com/ostinelli/erlcassa.git",
    {branch, "master"}}},
   {riakc, ".*",
-   {git, "git://github.com/basho/riak-erlang-client", {tag, "1.3.3"}}},
+   {git, "git://github.com/basho/riak-erlang-client", {tag, "1.4.1"}}},
   {mochiweb, "1.5.1",
    {git, "git://github.com/basho/mochiweb", {tag, "1.5.1-riak-1.0.x-fixes"}}},
   {getopt, ".*",

--- a/src/basho_bench_driver_riakc_pb.erl
+++ b/src/basho_bench_driver_riakc_pb.erl
@@ -39,7 +39,7 @@
                  indexes}).
 
 -define(MR_MULTIGET,
-        [{map, {modfun, riak_kv_mapreduce, map_object_value}, none, true}]).
+        [{map, {modfun, riak_kv_mapreduce, map_object_value}, <<"filter_notfound">>, true}]).
 -define(ERLANG_MR,
         [{map, {modfun, riak_kv_mapreduce, map_object_value}, none, false},
          {reduce, {modfun, riak_kv_mapreduce, reduce_count_inputs}, none, true}]).
@@ -242,8 +242,17 @@ run({get_index, IndexName, Range}, _KeyGen, _ValueGen, State) ->
 run({mr_multiget, ItemCount}, KeyGen, _ValueGen, State) when is_integer(ItemCount) andalso ItemCount > 0 ->
     KeyList = make_keylist(State#state.bucket, KeyGen, ItemCount),
     case riakc_pb_socket:mapred(State#state.pid, KeyList, ?MR_MULTIGET) of
-        {ok, _} ->
+        {ok, []} ->
+            io:format("Incorrect number of results for mr_multiget. Expected ~p, Received 0~n", [ItemCount]),
             {ok, State};
+        {ok, [{_, Results}]} ->
+            case length(Results) of
+                ItemCount ->
+                    {ok, State};
+                N ->
+                    io:format("Incorrect number of results for mr_multiget. Expected ~p, Received ~p~n", [ItemCount, N]),
+                    {ok, State}
+            end;
         {error, Reason} ->
             {error, Reason, State}
     end;

--- a/src/basho_bench_driver_riakc_pb.erl
+++ b/src/basho_bench_driver_riakc_pb.erl
@@ -2,7 +2,7 @@
 %%
 %% basho_bench_driver_riakc_pb: Driver for riak protocol buffers client
 %%
-%% Copyright (c) 2009 Basho Techonologies
+%% Copyright (c) 2009-2013 Basho Techonologies
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -35,8 +35,11 @@
                  dw,
                  rw,
                  keylist_length,
-                 preloaded_keys}).
+                 preloaded_keys,
+                 indexes}).
 
+-define(MR_MULTIGET,
+        [{map, {modfun, riak_kv_mapreduce, map_object_value}, none, true}]).
 -define(ERLANG_MR,
         [{map, {modfun, riak_kv_mapreduce, map_object_value}, none, false},
          {reduce, {modfun, riak_kv_mapreduce, reduce_count_inputs}, none, true}]).
@@ -72,6 +75,7 @@ new(Id) ->
     PreloadedKeys = basho_bench_config:get(
                       riakc_pb_preloaded_keys, undefined),
     warn_bucket_mr_correctness(PreloadedKeys),
+    Indexes  = process_index_config(basho_bench_config:get(secondary_indexes, []), []),
 
     %% Choose the target node using our ID as a modulus
     Targets = basho_bench_config:normalize_ips(Ips, Port),
@@ -86,7 +90,8 @@ new(Id) ->
                           dw = DW,
                           rw = RW,
                           keylist_length = KeylistLength,
-                          preloaded_keys = PreloadedKeys
+                          preloaded_keys = PreloadedKeys,
+                          indexes = Indexes
                          }};
         {error, Reason2} ->
             ?FAIL_MSG("Failed to connect riakc_pb_socket to ~p:~p: ~p\n",
@@ -139,9 +144,9 @@ run(get_existing, KeyGen, _ValueGen, State) ->
             {error, Reason, State}
     end;
 run(put, KeyGen, ValueGen, State) ->
-    Robj0 = riakc_obj:new(State#state.bucket, KeyGen()),
-    Robj = riakc_obj:update_value(Robj0, ValueGen()),
-    case riakc_pb_socket:put(State#state.pid, Robj, [{w, State#state.w},
+    Robj1 = riakc_obj:new(State#state.bucket, KeyGen(), ValueGen()),
+    Robj2 = riakc_obj:update_metadata(Robj1, ensure_2i_set(dict:new(), State)),
+    case riakc_pb_socket:put(State#state.pid, Robj2, [{w, State#state.w},
                                                      {dw, State#state.dw}]) of
         ok ->
             {ok, State};
@@ -153,7 +158,8 @@ run(update, KeyGen, ValueGen, State) ->
     case riakc_pb_socket:get(State#state.pid, State#state.bucket,
                              Key, [{r, State#state.r}]) of
         {ok, Robj} ->
-            Robj2 = riakc_obj:update_value(Robj, ValueGen()),
+            Robj1 = riakc_obj:update_value(Robj, ValueGen()),
+            Robj2 = riakc_obj:update_metadata(Robj1, ensure_2i_set(dict:new(), State)),
             case riakc_pb_socket:put(State#state.pid, Robj2, [{w, State#state.w},
                                                               {dw, State#state.dw}]) of
                 ok ->
@@ -162,9 +168,9 @@ run(update, KeyGen, ValueGen, State) ->
                     {error, Reason, State}
             end;
         {error, notfound} ->
-            Robj0 = riakc_obj:new(State#state.bucket, Key),
-            Robj = riakc_obj:update_value(Robj0, ValueGen()),
-            case riakc_pb_socket:put(State#state.pid, Robj, [{w, State#state.w},
+            Robj1 = riakc_obj:new(State#state.bucket, Key, ValueGen()),
+            Robj2 = riakc_obj:update_metadata(Robj1, ensure_2i_set(dict:new(), State)),
+            case riakc_pb_socket:put(State#state.pid, Robj2, [{w, State#state.w},
                                                              {dw, State#state.dw}]) of
                 ok ->
                     {ok, State};
@@ -177,7 +183,8 @@ run(update_existing, KeyGen, ValueGen, State) ->
     case riakc_pb_socket:get(State#state.pid, State#state.bucket,
                              Key, [{r, State#state.r}]) of
         {ok, Robj} ->
-            Robj2 = riakc_obj:update_value(Robj, ValueGen()),
+            Robj1 = riakc_obj:update_value(Robj, ValueGen()),
+            Robj2 = riakc_obj:update_metadata(Robj1, ensure_2i_set(dict:new(), State)),
             case riakc_pb_socket:put(State#state.pid, Robj2, [{w, State#state.w},
                                                               {dw, State#state.dw}]) of
                 ok ->
@@ -203,6 +210,39 @@ run(listkeys, _KeyGen, _ValueGen, State) ->
     %% Pass on rw
     case riakc_pb_socket:list_keys(State#state.pid, State#state.bucket) of
         {ok, _Keys} ->
+            {ok, State};
+        {error, Reason} ->
+            {error, Reason, State}
+    end;
+run({get_index, IndexName, Range}, _KeyGen, _ValueGen, State) ->
+    I = string:to_lower(IndexName),
+    case proplists:lookup(I, State#state.indexes) of
+        none ->
+            Error = io_lib:format("Secondary index ~p that is specified for get_index operation has not been defined.\n", [IndexName]),
+            {error, Error, State};
+        {I, {integer_index, Start, End}} ->
+            Rnd = get_ranged_random_int(Start, End),
+            case riakc_pb_socket:get_index(State#state.pid, State#state.bucket, {integer_index, I}, Rnd, ((Rnd + Range - 1))) of
+                {ok, _Results} ->
+                    {ok, State};
+                {error, Reason} ->
+                    {error, Reason, State}
+            end;
+        {I, {binary_index, Start, End, Fmt}} ->
+            Rnd = get_ranged_random_int(Start, End),
+            BS = list_to_binary(io_lib:format(Fmt, [Rnd])),
+            BE = list_to_binary(io_lib:format(Fmt, [(Rnd + Range - 1)])),
+            case riakc_pb_socket:get_index(State#state.pid, State#state.bucket, {binary_index, I}, BS, BE) of
+                {ok, _Results} ->
+                    {ok, State};
+                {error, Reason} ->
+                    {error, Reason, State}
+            end
+    end;
+run({mr_multiget, ItemCount}, KeyGen, _ValueGen, State) when is_integer(ItemCount) andalso ItemCount > 0 ->
+    KeyList = make_keylist(State#state.bucket, KeyGen, ItemCount),
+    case riakc_pb_socket:mapred(State#state.pid, KeyList, ?MR_MULTIGET) of
+        {ok, _} ->
             {ok, State};
         {error, Reason} ->
             {error, Reason, State}
@@ -306,3 +346,49 @@ mapred_ordered_valgen(Id) ->
             put(Save, Next+1),
             list_to_binary(integer_to_list(Next))
     end.
+
+process_index_config([], Validated) ->
+    Validated;
+process_index_config([{IndexName, integer_index, Start, End} | List], Validated) when is_list(IndexName) 
+                                                                   andalso is_integer(Start)
+                                                                   andalso is_integer(End) 
+                                                                   andalso End > Start ->
+    process_index_config(List, [{string:to_lower(IndexName), {integer_index, Start, End}} | Validated]);
+process_index_config([{IndexName, binary_index, Start, End} | List], Validated) when is_list(IndexName) 
+                                                                   andalso is_integer(Start)
+                                                                   andalso is_integer(End) 
+                                                                   andalso End > Start ->
+    Fmt = "\~" ++ integer_to_list(length(integer_to_list(End))) ++ ".10.0B",
+    process_index_config(List, [{string:to_lower(IndexName), {binary_index, Start, End, Fmt}} | Validated]);
+process_index_config([{IndexName, _, _} | List], Validated) ->
+    ?ERROR("Secondary index ~p not correctly configured and will be dropped\n", [IndexName]),
+    process_index_config(List, Validated);
+process_index_config([Index | List], Validated) ->
+    ?ERROR("Secondary index (~p) not correctly configured and will be dropped\n", [Index]),
+    process_index_config(List, Validated).
+
+ensure_2i_set(MD, State) ->
+    case riakc_obj:get_secondary_indexes(MD) of
+        [] ->
+            add_all_2i(MD, State);
+        _ ->
+            MD
+    end.
+
+add_all_2i(MD, State) ->
+    add_2i(MD, State#state.indexes).
+
+add_2i(MD, []) ->
+    MD;
+add_2i(MD, [{IndexName, {binary_index, Start, End, Fmt}} | Rest]) ->
+    Rnd = get_ranged_random_int(Start, End),
+    BinVal = list_to_binary(io_lib:format(Fmt, [Rnd])),
+    MDU = riakc_obj:add_secondary_index(MD, {{binary_index, IndexName}, [BinVal]}),
+    add_2i(MDU, Rest);
+add_2i(MD, [{IndexName, {integer_index, Start, End}} | Rest]) ->
+    Rnd = get_ranged_random_int(Start, End),
+    MDU = riakc_obj:add_secondary_index(MD, {{integer_index, IndexName}, [Rnd]}),
+    add_2i(MDU, Rest).
+
+get_ranged_random_int(Start, End) ->
+    random:uniform(End - Start + 1) - 1 + Start.


### PR DESCRIPTION
Moved riak-erlang-client dependency from version 1.2.1 to 1.3.3.

Added ability to add secondary indexes and benchmark simple secondary index queries. 

Also added functionality to benchmark basic multi-get queries emulated over map/reduce. Although we discourage implementing multi-gets on top of map/reduce, having the functionality there will allow users contemplating using it to more easily set up benchmarks and examine what level of performance one can typically expect and what effects it may have on the cluster.
