### PR TITLE
Fix partitioned seq int gen leaving some keys out

### DIFF
--- a/src/basho_bench_keygen.erl
+++ b/src/basho_bench_keygen.erl
@@ -72,7 +72,9 @@ new({partitioned_sequential_int, StartKey, NumKeys}, Id) ->
     Workers = basho_bench_config:get(concurrent),
     Range = NumKeys div Workers,
     MinValue = StartKey + Range * (Id - 1),
-    MaxValue = StartKey + Range * Id,
+    MaxValue = StartKey +
+               % Last worker picks up remainder to include entire range
+               case Workers == Id of true-> NumKeys; false -> Range * Id end,
     Ref = make_ref(),
     DisableProgress =
         basho_bench_config:get(disable_sequential_int_progress_report, false),


### PR DESCRIPTION
Fixes #75
For example, with 12 workers and 100 keys, it leaves the 4 last keys out
(100 rem 12).  This makes those keys (at most # of workers) be given to
the last worker.
