### PR TITLE
Add valgen to keygen adapter

### DIFF
--- a/src/basho_bench_keygen.erl
+++ b/src/basho_bench_keygen.erl
@@ -99,6 +99,10 @@ new({function, Module, Function, Args}, Id) ->
         _Error ->
             ?FAIL_MSG("Could not find keygen function: ~p:~p\n", [Module, Function])
     end;
+%% Adapt a value generator. The function keygen would work if Id was added as 
+%% the last parameter. But, alas, it is added as the first.
+new({valgen, ValGen}, Id) ->
+    basho_bench_valgen:new(ValGen, Id);
 new(Bin, _Id) when is_binary(Bin) ->
     fun() -> Bin end;
 new(Other, _Id) ->


### PR DESCRIPTION
Using this for a test that requires control of key length and # of keys,
for which I'm concatenating a binary value generator and int gens
