### PR TITLE
fix setting log level

### DIFF
--- a/src/basho_bench.erl
+++ b/src/basho_bench.erl
@@ -73,6 +73,10 @@ main(Args) ->
     %% show.
     basho_bench_config:load(Configs),
 
+    %% Log level can be overriden by the config files
+    CustomLagerLevel = basho_bench_config:get(log_level),
+    lager:set_loglevel(lager_console_backend, CustomLagerLevel),
+
     %% Init code path
     add_code_paths(basho_bench_config:get(code_paths, [])),
 


### PR DESCRIPTION
Allow the console log level to be customisable in the app or config files

The old config key log_level was I think abandoned when switching to lager. Now I've changed it to affect the level of lager_console_backend. I was not sure if it should also set the "console.log". Probably not as it is useful to have at least one file to contain all messages.

Anyway I guess the below page needs to be updated and cleared from any reference to basho_bench_log.erl
http://docs.basho.com/riak/latest/cookbooks/Benchmarking/
