### PR TITLE
Fix partitioned seq int to cover entire range

### DIFF
--- a/src/basho_bench_keygen.erl
+++ b/src/basho_bench_keygen.erl
@@ -80,7 +80,7 @@ new({partitioned_sequential_int, StartKey, NumKeys}, Id) ->
     DisableProgress =
         basho_bench_config:get(disable_sequential_int_progress_report, false),
     ?DEBUG("ID ~p generating range ~p to ~p\n", [Id, MinValue, MaxValue]),
-    fun() -> sequential_int_generator(Ref, Range, Id, DisableProgress) + MinValue end;
+    fun() -> sequential_int_generator(Ref, MaxValue - MinValue, Id, DisableProgress) + MinValue end;
 new({uniform_int, MaxKey}, _Id) ->
     fun() -> random:uniform(MaxKey) end;
 new({uniform_int, StartKey, NumKeys}, _Id) ->


### PR DESCRIPTION
I had a previous fix that unfortunately only _printed_ the correct
range, but did not generate it :(.  Previously the code left out a
number of keys on the end of the range due to the way it was doing
integer division and giving all workers the same number of ints.
This makes the last worker pick up the remainder.
