### PR TITLE
Add counters to riakc_pb driver

### DIFF
--- a/examples/counters.config
+++ b/examples/counters.config
@@ -8,7 +8,7 @@
 
 {key_generator, {int_to_bin, {uniform_int, 10000}}}.
 
-{value_generator, {random_int, 50}}.
+{value_generator, {uniform_int, 50}}.
 
 {riakc_pb_ips, [{127,0,0,1}]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -32,7 +32,7 @@
 {erl_opts, [{src_dirs, [src]},
            {parse_transform, lager_transform}]}.
 
-{escript_incl_apps, [lager, getopt, bear, folsom, ibrowse, riakc, riak_pb, mochiweb, protobuffs, velvet]}.
+{escript_incl_apps, [lager, getopt, bear, folsom, ibrowse, riakc, mochiweb, protobuffs, velvet]}.
 
 {escript_emu_args, "%%! +K true\n"}.
 %% Use this for the Java client bench driver

--- a/src/basho_bench_driver_2i.erl
+++ b/src/basho_bench_driver_2i.erl
@@ -351,9 +351,6 @@ to_list(B) when is_binary(B) ->
 to_list(I) when is_integer(I) ->
     integer_to_list(I).
 
-choose(N, L) ->
-    lists:nth((N rem length(L) + 1), L).
-
 json_get(Url) ->
     Response = ibrowse:send_req(lists:flatten(Url), [], get),
     case Response of

--- a/src/basho_bench_valgen.erl
+++ b/src/basho_bench_valgen.erl
@@ -52,8 +52,10 @@ new({function, Module, Function, Args}, Id) ->
         _Error ->
             ?FAIL_MSG("Could not find valgen function: ~p:~p\n", [Module, Function])
     end;
-new({random_int, MaxSize}, _Id) ->
-    fun() -> random:uniform(MaxSize) end;
+new({uniform_int, MaxVal}, _Id) ->
+    fun() -> random:uniform(MaxVal) end;
+new({uniform_int, MinVal, MaxVal}, _Id) ->
+    fun() -> random:uniform(MinVal, MaxVal) end;
 new(Other, _Id) ->
     ?FAIL_MSG("Unsupported value generator requested: ~p\n", [Other]).
 


### PR DESCRIPTION
Ability to bench counters.

Note: counter buckets _MUST_ be `allow_mult=true`. In this case I would set a new bucket, with `riakc_pb_bucket` in the config, since using the default `<<"test">>` bucket will cause conflicts with other pb test runs.

Also, requires the added `random_int` val gen, so can't be mixed with other pb operations at the moment, though maybe I'll change that, if the reviewer thinks it is best just to use random in `run/4`
