### PR TITLE
badarith crash from 2i driver

### DIFF
--- a/src/basho_bench_driver_2i.erl
+++ b/src/basho_bench_driver_2i.erl
@@ -308,8 +308,8 @@ run({query_pb, MaxN}, KeyGen, _ValueGen, State) ->
     Bucket = State#state.bucket,
     {StartKey, EndKey, MaxKey, N} = expected_n(to_integer(KeyGen()), State#state.max_key, MaxN),
     case {riakc_pb_socket:get_index(Pid, Bucket, <<"field1_int">>,
-                                   to_binary(StartKey), to_binary(EndKey),
-                                    State#state.pb_timeout), MaxKey} of
+				    to_binary(StartKey), to_binary(EndKey),
+                                    State#state.pb_timeout, State#state.pb_timeout), MaxKey} of
         {{ok, Results}, _} when length(Results) == N ->
             {ok, State};
         {{ok, Results}, undefined} ->


### PR DESCRIPTION
When running the 2i example (having stood up a 4-node cluster that uses leveldb), I get the following stack trace (formatting added):

``` erlang

19:53:59.578 [debug] Driver basho_bench_driver_2i crashed: 
{badarith,[
 {riakc_pb_socket,send_mapred_req,4,[{file,"src/riakc_pb_socket.erl"},{line,1168}]},
 {riakc_pb_socket,mapred,5,[{file,"src/riakc_pb_socket.erl"},{line,510}]},
 {riakc_pb_socket,get_index,6,[{file,"src/riakc_pb_socket.erl"},{line,703}]},
 {basho_bench_driver_2i,run,4,[{file,"src/basho_bench_driver_2i.erl"},{line,310}]},
 {basho_bench_worker,worker_next_op2,2,[{file,"src/basho_bench_worker.erl"},
 {line,233}]},{basho_bench_worker,worker_next_op,1,[{file,"src/basho_bench_worker.erl"},{line,239}]},
 {basho_bench_worker,max_worker_run_loop,1,[{file,"src/basho_bench_worker.erl"},{line,314}]}
]}
```

The source of the problem is that is basho_bench_driver_2i.erl:310:

``` erlang


    case {riakc_pb_socket:get_index(Pid, Bucket, <<"field1_int">>,
                    to_binary(StartKey), to_binary(EndKey),
                                    State#state.pb_timeout), MaxKey} of
```

The 5th argument, "to_binary(EndKey)" corresponds to get_index/6's "Timeout" arg.

I think that either the final argument should be removed (to make the call get_index/5) or another timeout arg added to make it get_index/7.  

Here's a pull request that does the latter, doubling up the pb_timeout arg to use that for both timeouts.
