### PR TITLE
Incorporate velvet R15 compatibility change

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -26,7 +26,7 @@
    {git, "git://github.com/basho/mochiweb", {tag, "1.5.1p6"}}},
   {velvet, "1.*",
    {git, "git://github.com/basho/velvet",
-    "d67255689535ede3312b68852dfc58df5b04cd1e"}},
+    "8739ba8d1630682830be0b95b45cfcbe933b6ad0"}},
   {getopt, ".*",
    {git, "git://github.com/jcomellas/getopt", {tag, "v0.4"}}}
  ]}.


### PR DESCRIPTION
Change Velvet dependency to the commit which fixes R15B compatibility, https://github.com/basho/velvet/pull/13 .
