### PR TITLE
Update to riak-erlang-client 1.4.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -21,7 +21,7 @@
    {git, "git://github.com/ostinelli/erlcassa.git",
    {branch, "master"}}},
   {riakc, ".*",
-   {git, "git://github.com/basho/riak-erlang-client", {tag, "1.2.1"}}},
+   {git, "git://github.com/basho/riak-erlang-client", {tag, "1.4.1"}}},
   {mochiweb, "1.5.1*",
    {git, "git://github.com/basho/mochiweb", {tag, "1.5.1p6"}}},
   {velvet, "1.*",
@@ -34,7 +34,7 @@
 {erl_opts, [{src_dirs, [src]},
            {parse_transform, lager_transform}]}.
 
-{escript_incl_apps, [lager, getopt, bear, folsom, ibrowse, riakc, mochiweb, protobuffs, velvet, goldrush]}.
+{escript_incl_apps, [lager, getopt, bear, folsom, ibrowse, riakc, riak_pb, mochiweb, protobuffs, velvet, goldrush]}.
 
 {escript_emu_args, "%%! +K true\n"}.
 %% Use this for the Java client bench driver


### PR DESCRIPTION
My reason for updating is to use the newer search API which doesn't require using map-reduce.  But this should be updated anyways.  The current client tag is very old.
