### PR TITLE
Fixes a bug in the URL round robin functionality where the first element...

### DIFF
--- a/src/basho_bench_driver_http_raw.erl
+++ b/src/basho_bench_driver_http_raw.erl
@@ -310,8 +310,7 @@ get_path(PL, [Name|Path]) ->
 next_url(State) when is_record(State#state.base_urls, url) ->
     {State#state.base_urls, State};
 next_url(State) when State#state.base_urls_index > tuple_size(State#state.base_urls) ->
-    { element(1, State#state.base_urls),
-      State#state { base_urls_index = 1 } };
+    next_url(State#state { base_urls_index = 1 });
 next_url(State) ->
     { element(State#state.base_urls_index, State#state.base_urls),
       State#state { base_urls_index = State#state.base_urls_index + 1 }}.


### PR DESCRIPTION
... would be pulled on successive calls at the end of each loop through the URL list.
