### PR TITLE
Expand latency graphing of basho_bench results

### DIFF
--- a/priv/summary.r
+++ b/priv/summary.r
@@ -7,7 +7,7 @@ arg0 <- sub("--file=(.*)", "\\1", grep("--file=", commandArgs(), value = TRUE))
 dir0 <- dirname(arg0)
 source(file.path(dir0, "common.r"))
 
-theme_set(theme_grey(base_size = 17)) 
+theme_set(theme_grey(base_size = 17))
 
 # Setup parameters for the script
 params = matrix(c(
@@ -53,10 +53,10 @@ plot1 <- qplot(elapsed, successful / window, data = b$summary,
                 geom = c("smooth", "point"),
                 xlab = "Elapsed Secs", ylab = opt$ylabel1stgraph,
                 main = "Throughput") +
-              
+
                 geom_smooth(aes(y = successful / window, colour = "ok"), size=0.5) +
                 geom_point(aes(y = successful / window, colour = "ok"), size=2.0) +
-                
+
                 geom_smooth(aes(y = failed / window, colour = "error"), size=0.5) +
                 geom_point(aes(y = failed / window, colour = "error"), size=2.0) +
 
@@ -68,22 +68,8 @@ latency_plot <- ggplot(b$latencies, aes(x = elapsed)) +
                    facet_grid(. ~ op) +
                    labs(x = "Elapsed Secs", y = "Latency (ms)")
 
-# Plot 99 and 99.9th percentiles
-plot2 <- latency_plot +
-            geom_smooth(aes(y = X99th, color = "99th"), size=0.5) +
-            geom_point(aes(y = X99th, color = "99th"), size=2.0) +
-
-            geom_smooth(aes(y = X99_9th, color = "99.9th"), size=0.5) +
-            geom_point(aes(y = X99_9th, color = "99.9th"), size=2.0) +
-            
-            scale_colour_manual("Percentile", values = c("#FF665F", "#009D91"))
-            # scale_color_hue("Percentile",
-            #                 breaks = c("X99_9th","X99th" ),
-            #                 labels = c("99.9th", "99th"))
-
-
 # Plot median, mean and 95th percentiles
-plot3 <- latency_plot +
+plot2 <- latency_plot + opts(title = "Mean, Median, and 95th Percentile Latency") +
             geom_smooth(aes(y = median, color = "median"), size=0.5) +
             geom_point(aes(y = median, color = "median"), size=2.0) +
 
@@ -98,14 +84,37 @@ plot3 <- latency_plot +
             #                 breaks = c("X95th", "mean", "median"),
             #                 labels = c("95th", "Mean", "Median"))
 
+# Plot 99th percentile
+plot3 <- latency_plot + opts(title = "99th Percentile Latency") +
+            geom_smooth(aes(y = X99th, color = "99th"), size=0.5) +
+            geom_point(aes(y = X99th, color = "99th"), size=2.0) +
+            scale_colour_manual("Percentile", values = c("#FF665F", "#009D91"))
+            # scale_color_hue("Percentile",
+            #                 breaks = c("X99_9th","X99th" ),
+            #                 labels = c("99.9th", "99th"))
+
+# Plot 99.9th percentile
+plot4 <- latency_plot + opts(title = "99.9th Percentile Latency") +
+            geom_smooth(aes(y = X99_9th, color = "99.9th"), size=0.5) +
+            geom_point(aes(y = X99_9th, color = "99.9th"), size=2.0) +
+            scale_colour_manual("Percentile", values = c("#FF665F", "#009D91", "#FFA700"))
+
+# Plot 100th percentile
+plot5 <- latency_plot + opts(title = "Maximum Latency") +
+            geom_smooth(aes(y = max, color = "max"), size=0.5) +
+            geom_point(aes(y = max, color = "max"), size=2.0) +
+            scale_colour_manual("Percentile", values = c("#FF665F", "#009D91", "#FFA700"))
+
 grid.newpage()
 
-pushViewport(viewport(layout = grid.layout(3, 1)))
+pushViewport(viewport(layout = grid.layout(5, 1)))
 
 vplayout <- function(x,y) viewport(layout.pos.row = x, layout.pos.col = y)
 
 print(plot1, vp = vplayout(1,1))
 print(plot2, vp = vplayout(2,1))
 print(plot3, vp = vplayout(3,1))
+print(plot4, vp = vplayout(4,1))
+print(plot5, vp = vplayout(5,1))
 
 dev.off()


### PR DESCRIPTION
Separate out the 99th and 99.9th percentiles into separate plots and add a
plot of maximum latency times. Also add titles to all graphs. This change
repsents a small cleanup and refactoring of work done by Matthew
Von-Maszewski.
