### PR TITLE
Allow applications to shutdown normally

### DIFF
--- a/src/basho_bench_app.erl
+++ b/src/basho_bench_app.erl
@@ -71,7 +71,7 @@ halt_or_kill() ->
         {ok, included} ->
             exit(whereis(basho_bench_sup),kill);
         _ ->
-            halt(1)
+            init:stop()
     end.
 
 %% ===================================================================


### PR DESCRIPTION
It's very important to shutdown properly or else log messages could
get swallowed and you'll have no idea why basho bench failed. I had an
issue in the `new/1` function of my driver and without this change
there was no indication as to why Basho Bench failed because halt was
causing lager to exit before it could log the failure reason.
