### PR TITLE
fix cassandra cql driver include path

### DIFF
--- a/src/basho_bench_driver_cassandra_cql.erl
+++ b/src/basho_bench_driver_cassandra_cql.erl
@@ -24,7 +24,7 @@
 -export([new/1,
          run/4]).
 
--include_lib("basho_bench.hrl").
+-include("basho_bench.hrl").
 
 -record(state, { client,
                  keyspace,


### PR DESCRIPTION
so you can build in with the directory name being something other than basho_bench.
