### PR TITLE
Remove extraneous 'thrift' dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,6 @@
   {casbench, "0.1",
    {git, "git://github.com/basho/casbench",
     "95ed55b494551577870984aeb1e0f683631a326f"}},
-  {thrift, ".*", {git, "git://github.com/lpgauth/thrift-erlang.git", {branch, "master"}}},
   {erlcql, ".*",
    {git, "git://github.com/rpt/erlcql.git",
    {branch, "master"}}},


### PR DESCRIPTION
The `thrift` dependency was introduced in b45e4d03d777c672c8870dfcc0dea186db4e6b94 but I removed the `erlcassa` dependency in 80a802b4be52c92612a4d20bb246c00a78625937.

Not making this change could actually cause `basho_bench_driver_cassandra.erl` to break if the code path search order is ever changed as both `thrift` and `casbench` include a `thrift_client.erl` module with different implementations. It just happens that `casbench`'s one is actually used and is first on the path.
