### PR TITLE
Use verbatim to keep error messages intact

### DIFF
--- a/README.org
+++ b/README.org
@@ -63,10 +63,10 @@ $ open tests/current/summary.png
 
 ** Troubleshooting Graph Generation
 
-   If make results fails with the error /usr/bin/env: Rscript --vanilla: No such file or directory
+   If make results fails with the error =/usr/bin/env: Rscript --vanilla: No such file or directory=
    please edit priv/summary.r and replace the first line with the full path to the Rscript binary on your system
 
-   If you receive the error message: Warning: unable to access index for repository http://lib.stat.cmu.edu/R/CRAN/src/contrib 
+   If you receive the error message =Warning: unable to access index for repository http://lib.stat.cmu.edu/R/CRAN/src/contrib= 
    it means the default R repo for installing additional packages is broken, you can change it as follows:
 
 #+BEGIN_SRC shell


### PR DESCRIPTION
This keeps GitHub's org processor from turning -- into — and making the error hard to read or locate by searching.
