### PR TITLE
Add a benchmark for concurrent map updates.

### DIFF
--- a/examples/teams-crdt-map.config
+++ b/examples/teams-crdt-map.config
@@ -1,0 +1,26 @@
+{mode,{rate,max}}.
+{duration,10}.
+{concurrent,150}.
+{rng_seed,now}.
+
+%% This bucket type must be created and set to be datatype, maps.
+{riakc_pb_bucket,{<<"maps">>,<<"testbucket">>}}.
+
+{key_generator, {uniform_int, 100}}.
+{value_generator, {uniform_int, 1000}}.
+
+{operations,[{{game,completed},10},
+             {{team,player,addition},3},
+             {{team,player,removal},3},
+             {{team,read},100},
+             {{team,write},1}]}.
+
+{riakc_pb_ips,[{"riak101.aws",10017},
+               {"riak102.aws",10017},
+               {"riak103.aws",10017},
+               {"riak104.aws",10017},
+               {"riak105.aws",10017}]}.
+
+{riakc_pb_replies,default}.
+
+{driver,basho_bench_driver_riakc_pb}.


### PR DESCRIPTION
Update a series of maps representing teams which are computed from
cumulative updates to a series of individual player scores.  Add and
remove members of the team, while concurrent score changes are
occurring.

cc: @russelldb 
