### PR TITLE
Make updates to key generators and example config files

### DIFF
--- a/examples/cassandra_cql.config
+++ b/examples/cassandra_cql.config
@@ -19,7 +19,7 @@
 {driver, basho_bench_driver_cassandra_cql}.
 
 %% Preload only
-%% {key_generator, {int_to_str, {sequential_int, 50000}}}.
+%% {key_generator, {int_to_str, {partitioned_sequential_int, 50000}}}.
 %% All other tests
 {key_generator, {int_to_str, {uniform_int, 50000}}}.
 

--- a/examples/null_err_test.config
+++ b/examples/null_err_test.config
@@ -7,7 +7,7 @@
 
 {driver, basho_bench_driver_null}.
 
-{key_generator, {sequential_int, 5000000}}.
+{key_generator, {partitioned_sequential_int, 5000000}}.
 {disable_sequential_int_progress_report, true}.
 {value_generator, {fixed_bin, 10248}}.
 

--- a/examples/null_test.config
+++ b/examples/null_test.config
@@ -7,7 +7,19 @@
 
 {driver, basho_bench_driver_null}.
 
-{key_generator, {sequential_int, 5000000}}.
+%% Simple key generator: generate a sequential integer (that is unique
+%% across concurrent worker processes), then convert it to a binary blob
+%% of 32 bits, big endian-style.  This will create binary keys that are in
+%% lexigraphic sorting order.
+%{key_generator, {int_to_bin_bigendian, {partitioned_sequential_int, 5000000}}}.
+
+%% More complex key generator:
+%%   * Generate a randon number between 1 and 40000000 (40 million)
+%%   * Convert it to a binary blob of 32 bits, big endian-style
+%%   * Prepend <<"seed1">>
+%%   * Hash the result with MD5, resulting in a 16 byte binary.
+{key_generator, {{crypto_hash, md5}, {concat_binary, <<"seed1">>, {int_to_bin_bigendian, {partitioned_sequential_int, 40000000}}}}}.
+
 {disable_sequential_int_progress_report, true}.
 {value_generator, {fixed_bin, 10248}}.
 

--- a/examples/riakc_mr.config
+++ b/examples/riakc_mr.config
@@ -13,7 +13,7 @@
 %% {duration, 10000}.
 %% {concurrent, 1}.
 %% {operations, [{put, 1}]}.
-%% {key_generator, {int_to_str, {sequential_int, 10000}}}.
+%% {key_generator, {int_to_str, {partitioned_sequential_int, 10000}}}.
 %% {value_generator,
 %%  {function, basho_bench_driver_riakc_pb, mapred_ordered_valgen, []}}.
 

--- a/examples/shortcut.config
+++ b/examples/shortcut.config
@@ -2,7 +2,7 @@
 {duration, infinity}.
 {concurrent, 8}.
 {driver, basho_bench_driver_shortcut}.
-{key_generator, {int_to_bin_bigendian,{sequential_int, 50000}}}.
+{key_generator, {int_to_bin_bigendian,{partitioned_sequential_int, 50000}}}.
 
 {value_generator, {fixed_bin, 100}}.
 

--- a/src/basho_bench.app.src
+++ b/src/basho_bench.app.src
@@ -1,6 +1,6 @@
 {application, basho_bench,
  [{description, "Riak Benchmarking Suite"},
-  {vsn, "0.1"},
+  {vsn, "0.9"},
   {modules, []},
   {registered, [ basho_bench_sup ]},
   {applications, [kernel,


### PR DESCRIPTION
- Change most example config files to use partitioned_sequential_int
  instead of sequential_int.  The latter is usually not what people
  want: each load generator uses the same overlapping set of sequential
  integers.  Especially for data setup/prepopulation use, you really
  want each concurrent worker to operate in keys unique from all of
  the other worker, i.e., GO FAST and do not repeat the work that some
  other worker has already done.
- Remove the deprecated int_to_bin generator.  Everyone should be using
  int_to_bin_bigendian or int_to_big_littleendian now.
- Add {int_to_bin_bigendian, Bits} and {int_to_bin_littleendian, Bits}
  generators, to avoid the otherwise-hard-coded limitation of 32 bits
  worth of output.
- Add the {crypto_hash, Type} generator.  Valid types are:
     Type == md4; Type == md5; Type == ripemd160; Type == sha; Type == sha224;
     Type == sha256; Type == sha384; Type == sha512 ->
- Bump the version number to 0.9 in the OTP app file.

cc: @reiddraper @ksauzz @kuenishi @shino 
