### PR TITLE
uuid module collides with actual dependency

### DIFF
--- a/src/basho_bench_keygen.erl
+++ b/src/basho_bench_keygen.erl
@@ -108,7 +108,7 @@ new({truncated_pareto_int, MaxKey}, Id) ->
     Pareto = new({pareto_int, MaxKey}, Id),
     fun() -> erlang:min(MaxKey, Pareto()) end;
 new(uuid_v4, _Id) ->
-    fun() -> uuid:v4() end;
+    fun() -> basho_uuid:v4() end;
 new({function, Module, Function, Args}, Id)
   when is_atom(Module), is_atom(Function), is_list(Args) ->
     case code:ensure_loaded(Module) of

--- a/src/basho_uuid.erl
+++ b/src/basho_uuid.erl
@@ -28,7 +28,7 @@
 % NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 % SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 %
--module(uuid).
+-module(basho_uuid).
 -export([v4/0, to_string/1, get_parts/1, to_binary/1]).
 
 % Generates a random binary UUID.


### PR DESCRIPTION
Unable to run tests with Cassandra’s [cqerl](https://github.com/matehat/cqerl) client which depends on the [uuid](https://github.com/okeuday/uuid.git) module due to a module name collision. I suggest namespacing the basho_bench uuid to avoid future conflicts.
