### PR TITLE
Use non-zero exit status for expressing failure

### DIFF
--- a/include/basho_bench.hrl
+++ b/include/basho_bench.hrl
@@ -1,5 +1,5 @@
 
--define(FAIL_MSG(Str, Args), ?ERROR(Str, Args), basho_bench_app:halt_or_kill()).
+-define(FAIL_MSG(Str, Args), ?ERROR(Str, Args), basho_bench_app:stop_or_kill()).
 -define(STD_ERR(Str, Args), io:format(standard_error, Str, Args)).
 
 -define(CONSOLE(Str, Args), lager:info(Str, Args)).

--- a/src/basho_bench_app.erl
+++ b/src/basho_bench_app.erl
@@ -27,7 +27,7 @@
 -export([start/0,
          stop/0,
          is_running/0,
-         halt_or_kill/0]).
+         stop_or_kill/0]).
 
 %% Application callbacks
 -export([start/2, stop/1]).
@@ -64,14 +64,14 @@ stop() ->
 is_running() ->
     application:get_env(basho_bench_app, is_running) == {ok, true}.
 
-halt_or_kill() ->
+stop_or_kill() ->
     %% If running standalone, halt and kill node.  Otherwise, just
     %% kill top supervisor.
     case application:get_env(basho_bench,app_run_mode) of
         {ok, included} ->
             exit(whereis(basho_bench_sup),kill);
         _ ->
-            init:stop()
+            init:stop(1)
     end.
 
 %% ===================================================================


### PR DESCRIPTION
This PR is an improvement following #117.
