### PR TITLE
Ensure values are read in as numeric.

### DIFF
--- a/priv/common.r
+++ b/priv/common.r
@@ -21,7 +21,8 @@ load_latency_frame <- function(File)
 load_benchmark <- function(Dir, Tstart, Tend)
   {
     ## Load up summary data
-    summary <- read.csv(sprintf("%s/%s", Dir, "summary.csv"))
+    summary <- read.csv(sprintf("%s/%s", Dir, "summary.csv"),
+                        colClasses=rep("numeric", 5))
 
     ## Get a list of latency files
     latencies <- lapply(list.files(path = Dir, pattern = "_latencies.csv",


### PR DESCRIPTION
Came across some situations where the values in summary.csv were read in as factors and the graph generation failed with "In Ops.factor(successful, window) : / not meaningful for factors". This change makes sure the values are always read in as numeric.
