### PR TITLE
Switch from erlcql to cqerl.

### DIFF
--- a/examples/cassandra_cql.config
+++ b/examples/cassandra_cql.config
@@ -38,4 +38,5 @@
 %%{operations, [{get, 1}]}.
 %%{operations, [{delete, 1}]}.
 
-{code_paths, ["./deps/erlcql/ebin"]}.
+{code_paths, ["./deps/cqerl/ebin", "./deps/pooler/ebin",  "./deps/uuid/ebin",
+              "./deps/semver/ebin"]}.

--- a/rebar.config
+++ b/rebar.config
@@ -24,8 +24,8 @@
   {casbench, "0.1",
    {git, "git://github.com/basho/casbench",
     "95ed55b494551577870984aeb1e0f683631a326f"}},
-  {erlcql, ".*",
-   {git, "git://github.com/rpt/erlcql.git",
+  {cqerl, ".*",
+   {git, "git://github.com/matehat/cqerl.git",
    {branch, "master"}}}
  ]}.
 


### PR DESCRIPTION
Unfortunately, erlcql only supports CQL3 over Cassandra binary protocol v1, while for recent Cassandras, we want v2. Thankfully, cqerl supports v2, and converting the cassandra_cql driver is reasonably simple.

This patch does just that - converts from erlcql to cqerl.

The change to `examples/cassandra_cql.config` can be avoided, if those deps are added to `escript_incl_apps` in `rebar.config`, but I think I'm starting to realize what that is good for, and why, so I opted to add it to the example instead. Let me know if I should move them elsewhere.
