### PR TITLE
fixing problem with operation names containing underscores

### DIFF
--- a/priv/common.r
+++ b/priv/common.r
@@ -13,7 +13,7 @@ for(p in packages.to.install)
 # Load a latency file and ensure that it is appropriately tagged
 load_latency_frame <- function(File)
   {
-    op <- strsplit(basename(File), "_")[[1]][1]
+    op <- gsub("_latencies.csv", "", basename(File))
     frame <- read.csv(File)
     frame$op = rep(op, nrow(frame))
     return (frame)


### PR DESCRIPTION
The problem I saw was with operations named "get" and "get_multi".
The current implementation will map both to the identifier "get" and overwrite one with the other.
