### PR TITLE
Slf 201412 minor fixups: a bit of everything

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -56,7 +56,16 @@
     snappy
 ]}.
 
-{escript_emu_args, "%%! +K true -rsh ssh\n"}.
-%% Use this for the Java client bench driver
-%% {escript_emu_args, "%%! +K true -name bb@127.0.0.1 -setcookie YOUR_ERLANG_COOKIE\n"}.
-{escript_emu_args, "%%! +K true -name bb@127.0.0.1 -setcookie YOUR_ERLANG_COOKIE -rsh ssh\n"}.
+%% When using the Java client bench driver, please use the -N and -C
+%% command line options to set the distributed Erlang node name
+%% and node cookie for the basho_bench VM.
+%% It isn't necessary to set the node name and cookie here.
+%%
+%% If you have any need to run basho_bench in an interactive way with
+%% the Erlang CLI, then remove the -noshell and -noinput flags.
+%%
+%% The value of +Q here is for 1.2 million ports, but the process
+%% won't be able to open that many ports without also adjusting the
+%% OS process's file descriptor limit, e.g., using "ulimit -n".
+
+{escript_emu_args, "%%! +K true -rsh ssh -noshell -noinput +P 1222333 +Q 1222333 +zdbbl 32768\n"}.

--- a/src/basho_bench_driver_http_raw.erl
+++ b/src/basho_bench_driver_http_raw.erl
@@ -364,8 +364,7 @@ do_get(Url, S) ->
     do_get(Url, [], S).
 
 do_get(Url, Opts, S) ->
-    SockOpts = [{reuseaddr, true}, {nodelay, true}, {delay_send, false}],
-    case send_request(Url, [], get, [], [{response_format, binary}, {socket_options, SockOpts}], S) of
+    case send_request(Url, [], get, [], [{response_format, binary}], S) of
         {ok, "404", _Headers, _Body} ->
             {not_found, Url};
         {ok, "300", Headers, _Body} ->
@@ -500,7 +499,9 @@ send_request(_Url, _Headers, _Method, _Body, _Options, 0, _S) ->
     {error, max_retries};
 send_request(Url, Headers, Method, Body, Options, Count, S) ->
     Pid = connect(Url),
-    Options2 = [S#state.opt_ssl_options | Options],
+    SockOpts = [{reuseaddr, true}, {nodelay, true}, {delay_send, false},
+                S#state.opt_ssl_options],
+    Options2 = Options ++ SockOpts,
     case catch(ibrowse_http_client:send_req(Pid, Url, Headers ++ S#state.opt_raw_headers, Method, Body, Options2, S#state.opt_request_timeout)) of
         {ok, Status, RespHeaders, RespBody} ->
             maybe_disconnect(Url),

--- a/src/basho_bench_driver_http_raw.erl
+++ b/src/basho_bench_driver_http_raw.erl
@@ -71,8 +71,6 @@ new(Id) ->
 
     %% Setup client ID by base-64 encoding the ID
     ClientId = {'X-Riak-ClientId', base64:encode(<<Id:32/unsigned>>)},
-    ?DEBUG("Client ID: ~p\n", [ClientId]),
-    ?INFO("CWD: ~p~n", [file:get_cwd()]),
 
     application:start(ibrowse),
 
@@ -347,7 +345,8 @@ do_get(Url) ->
     do_get(Url, []).
 
 do_get(Url, Opts) ->
-    case send_request(Url, [], get, [], [{response_format, binary}]) of
+    SockOpts = [{reuseaddr, true}, {nodelay, true}, {delay_send, false}],
+    case send_request(Url, [], get, [], [{response_format, binary}, {socket_options, SockOpts}]) of
         {ok, "404", _Headers, _Body} ->
             {not_found, Url};
         {ok, "300", Headers, _Body} ->

--- a/src/basho_bench_driver_http_raw.erl
+++ b/src/basho_bench_driver_http_raw.erl
@@ -34,7 +34,11 @@
                  files,              % List of files to put
                  path_params,        % Params to append on the path
                  solr_path,          % SOLR path for searches
-                 searchgen }).       % Search generator
+                 searchgen,          % Search generator
+                 opt_ssl_options,
+                 opt_raw_headers,
+                 opt_request_timeout
+               }).
 
 
 -define(NOT_EXPECTED(Qry, Expected, Actual),
@@ -110,17 +114,32 @@ new(Id) ->
                               || {IP, Port} <- Targets]),
     BaseUrlsIndex = random:uniform(tuple_size(BaseUrls)),
 
+    SSL_options = case basho_bench_config:get(http_use_ssl, false) of
+                      false ->
+                          [];
+                      true ->
+                          [{is_ssl, true}, {ssl_options, []}];
+                      SSLOpts when is_list(SSLOpts) ->
+                          [{is_ssl, true}, {ssl_options, SSLOpts}]
+                  end,
+    RawHeaders = basho_bench_config:get(http_raw_append_headers,[]),
+    RequestTimeout = basho_bench_config:get(http_raw_request_timeout, 5000),
+
     {ok, #state { client_id = ClientId,
                   base_urls = BaseUrls,
                   base_urls_index = BaseUrlsIndex,
                   files = Files,
                   path_params = Params,
                   solr_path = SolrPath,
-                  searchgen = SearchGen }}.
+                  searchgen = SearchGen,
+                  opt_ssl_options = SSL_options,
+                  opt_raw_headers = RawHeaders,
+                  opt_request_timeout = RequestTimeout
+                }}.
 
 run(stat, _, _, State) ->
     {Url, S2} = next_url(State),
-    case do_stat(stat_url(Url)) of
+    case do_stat(stat_url(Url), State) of
         {ok, _, _} ->
             {ok, S2};
         {error, Reason} ->
@@ -129,7 +148,7 @@ run(stat, _, _, State) ->
 
 run(get, KeyGen, _ValueGen, State) ->
     {NextUrl, S2} = next_url(State),
-    case do_get(url(NextUrl, KeyGen, State#state.path_params)) of
+    case do_get(url(NextUrl, KeyGen, State#state.path_params), State) of
         {not_found, _Url} ->
             {ok, S2};
         {ok, _Url, _Headers} ->
@@ -139,7 +158,7 @@ run(get, KeyGen, _ValueGen, State) ->
     end;
 run(get_existing, KeyGen, _ValueGen, State) ->
     {NextUrl, S2} = next_url(State),
-    case do_get(url(NextUrl, KeyGen, State#state.path_params)) of
+    case do_get(url(NextUrl, KeyGen, State#state.path_params), State) of
         {not_found, Url} ->
             {error, {not_found, Url}, S2};
         {ok, _Url, _Headers} ->
@@ -149,12 +168,12 @@ run(get_existing, KeyGen, _ValueGen, State) ->
     end;
 run(update, KeyGen, ValueGen, State) ->
     {NextUrl, S2} = next_url(State),
-    case do_get(url(NextUrl, KeyGen, State#state.path_params)) of
+    case do_get(url(NextUrl, KeyGen, State#state.path_params), State) of
         {error, Reason} ->
             {error, Reason, S2};
 
         {not_found, Url} ->
-            case do_put(Url, [], ValueGen) of
+            case do_put(Url, [], ValueGen, State) of
                 ok ->
                     {ok, S2};
                 {error, Reason} ->
@@ -163,7 +182,7 @@ run(update, KeyGen, ValueGen, State) ->
 
         {ok, Url, Headers} ->
             Vclock = lists:keyfind("X-Riak-Vclock", 1, Headers),
-            case do_put(Url, [State#state.client_id, Vclock], ValueGen) of
+            case do_put(Url, [State#state.client_id, Vclock], ValueGen, State) of
                 ok ->
                     {ok, S2};
                 {error, Reason} ->
@@ -172,7 +191,7 @@ run(update, KeyGen, ValueGen, State) ->
     end;
 run(update_existing, KeyGen, ValueGen, State) ->
     {NextUrl, S2} = next_url(State),
-    case do_get(url(NextUrl, KeyGen, State#state.path_params)) of
+    case do_get(url(NextUrl, KeyGen, State#state.path_params), State) of
         {error, Reason} ->
             {error, Reason, S2};
 
@@ -181,7 +200,7 @@ run(update_existing, KeyGen, ValueGen, State) ->
 
         {ok, Url, Headers} ->
             Vclock = lists:keyfind("X-Riak-Vclock", 1, Headers),
-            case do_put(Url, [State#state.client_id, Vclock], ValueGen) of
+            case do_put(Url, [State#state.client_id, Vclock], ValueGen, State) of
                 ok ->
                     {ok, S2};
                 {error, Reason} ->
@@ -195,7 +214,7 @@ run(insert, KeyGen, ValueGen, State) ->
     %% output of the keygen is ignored.
     KeyGen(),
     {NextUrl, S2} = next_url(State),
-    case do_post(url(NextUrl, State#state.path_params), [], ValueGen) of
+    case do_post(url(NextUrl, State#state.path_params), [], ValueGen, State) of
         ok ->
             {ok, S2};
         {error, Reason} ->
@@ -204,7 +223,7 @@ run(insert, KeyGen, ValueGen, State) ->
 run(put, KeyGen, ValueGen, State) ->
     {NextUrl, S2} = next_url(State),
     Url = url(NextUrl, KeyGen, State#state.path_params),
-    case do_put(Url, [State#state.client_id], ValueGen) of
+    case do_put(Url, [State#state.client_id], ValueGen, State) of
         ok ->
             {ok, S2};
         {error, Reason} ->
@@ -213,7 +232,7 @@ run(put, KeyGen, ValueGen, State) ->
 run(delete, KeyGen, _ValueGen, State) ->
     {NextUrl, S2} = next_url(State),
     Url = url(NextUrl, KeyGen, State#state.path_params),
-    case do_delete(Url, [State#state.client_id]) of
+    case do_delete(Url, [State#state.client_id], State) of
         ok ->
             {ok, S2};
         {error, Reason} ->
@@ -230,7 +249,7 @@ run(put_file, _, _, State) ->
     Key = filename:basename(File),
     {ok, Val} = file:read_file(File),
     Url = url(NextUrl, Key, State#state.path_params),
-    case do_put(Url, [State#state.client_id], Val) of
+    case do_put(Url, [State#state.client_id], Val, State) of
         ok -> {ok, S3};
         {error, Reason} -> {error, Reason, S3}
     end;
@@ -240,7 +259,7 @@ run({search, {Qry, Expected}}, _, _, State) ->
     SolrPath = State#state.solr_path,
     Encoded = mochiweb_util:urlencode([{q, Qry}, {wt, "json"}, {fl, "id"}]),
     SearchUrl = search_url(NextUrl, SolrPath, Encoded),
-    Res = do_get(SearchUrl, [{body_on_success, true}]),
+    Res = do_get(SearchUrl, [{body_on_success, true}], State),
     case Res of
         {ok, _, _, Body} ->
             Struct = mochijson2:decode(Body),
@@ -262,7 +281,7 @@ run(search, _KeyGen, _ValueGen, State) ->
     %% Handle missing searchgen
     {NextUrl, S2} = next_url(State),
     SearchUrl = search_url(NextUrl, State#state.solr_path, State#state.searchgen),
-    SearchRes = do_get(SearchUrl),
+    SearchRes = do_get(SearchUrl, State),
     case SearchRes of
         {ok, _Url, _Headers} ->
             {ok, S2};
@@ -331,8 +350,8 @@ search_url(BaseUrl, SolrPath, SearchGen) ->
 stat_url(BaseUrl) ->
     BaseUrl#url{path="/stats"}.
 
-do_stat(Url) ->
-    case send_request(Url, [], get, [], [{response_format, binary}]) of
+do_stat(Url, S) ->
+    case send_request(Url, [], get, [], [{response_format, binary}], S) of
         {ok, "200", Headers, _Body} ->
             {ok, Url, Headers};
         {ok, Code, _, _} ->
@@ -341,12 +360,12 @@ do_stat(Url) ->
             {error, Reason}
     end.
 
-do_get(Url) ->
-    do_get(Url, []).
+do_get(Url, S) ->
+    do_get(Url, [], S).
 
-do_get(Url, Opts) ->
+do_get(Url, Opts, S) ->
     SockOpts = [{reuseaddr, true}, {nodelay, true}, {delay_send, false}],
-    case send_request(Url, [], get, [], [{response_format, binary}, {socket_options, SockOpts}]) of
+    case send_request(Url, [], get, [], [{response_format, binary}, {socket_options, SockOpts}], S) of
         {ok, "404", _Headers, _Body} ->
             {not_found, Url};
         {ok, "300", Headers, _Body} ->
@@ -362,14 +381,14 @@ do_get(Url, Opts) ->
             {error, Reason}
     end.
 
-do_put(Url, Headers, ValueGen) ->
+do_put(Url, Headers, ValueGen, S) ->
     Val = if is_function(ValueGen) ->
                   ValueGen();
              true ->
                   ValueGen
           end,
     case send_request(Url, Headers ++ [{'Content-Type', 'application/octet-stream'}],
-                      put, Val, [{response_format, binary}]) of
+                      put, Val, [{response_format, binary}], S) of
         {ok, "204", _Header, _Body} ->
             ok;
         {ok, Code, _Header, _Body} ->
@@ -378,9 +397,9 @@ do_put(Url, Headers, ValueGen) ->
             {error, Reason}
     end.
 
-do_post(Url, Headers, ValueGen) ->
+do_post(Url, Headers, ValueGen, S) ->
     case send_request(Url, Headers ++ [{'Content-Type', 'application/octet-stream'}],
-                      post, ValueGen(), [{response_format, binary}]) of
+                      post, ValueGen(), [{response_format, binary}], S) of
         {ok, "201", _Header, _Body} ->
             ok;
         {ok, "204", _Header, _Body} ->
@@ -391,8 +410,8 @@ do_post(Url, Headers, ValueGen) ->
             {error, Reason}
     end.
 
-do_delete(Url, Headers) ->
-    case send_request(Url, Headers, delete, [], []) of
+do_delete(Url, Headers, S) ->
+    case send_request(Url, Headers, delete, [], [], S) of
         {ok, "204", _Header, _Body} ->
             ok;
         {ok, "404", _Header, _Body} ->
@@ -474,22 +493,15 @@ clear_disconnect_freq(Url) ->
         _Seconds -> erlang:put({last_disconnect, Url#url.host}, erlang:now())
     end.
 
-send_request(Url, Headers, Method, Body, Options) ->
-    send_request(Url, Headers, Method, Body, Options, 3).
+send_request(Url, Headers, Method, Body, Options, S) ->
+    send_request(Url, Headers, Method, Body, Options, 3, S).
 
-send_request(_Url, _Headers, _Method, _Body, _Options, 0) ->
+send_request(_Url, _Headers, _Method, _Body, _Options, 0, _S) ->
     {error, max_retries};
-send_request(Url, Headers, Method, Body, Options, Count) ->
+send_request(Url, Headers, Method, Body, Options, Count, S) ->
     Pid = connect(Url),
-    Options2 = case basho_bench_config:get(http_use_ssl, false) of
-                   false ->
-                       Options;
-                   true ->
-                       [{is_ssl, true}, {ssl_options, []} | Options];
-                   SSLOpts when is_list(SSLOpts) ->
-                       [{is_ssl, true}, {ssl_options, SSLOpts} | Options]
-               end,
-    case catch(ibrowse_http_client:send_req(Pid, Url, Headers ++ basho_bench_config:get(http_raw_append_headers,[]), Method, Body, Options2, basho_bench_config:get(http_raw_request_timeout, 5000))) of
+    Options2 = [S#state.opt_ssl_options | Options],
+    case catch(ibrowse_http_client:send_req(Pid, Url, Headers ++ S#state.opt_raw_headers, Method, Body, Options2, S#state.opt_request_timeout)) of
         {ok, Status, RespHeaders, RespBody} ->
             maybe_disconnect(Url),
             {ok, Status, RespHeaders, RespBody};
@@ -499,7 +511,7 @@ send_request(Url, Headers, Method, Body, Options, Count) ->
             disconnect(Url),
             case should_retry(Error) of
                 true ->
-                    send_request(Url, Headers, Method, Body, Options, Count-1);
+                    send_request(Url, Headers, Method, Body, Options, Count-1, S);
 
                 false ->
                     normalize_error(Method, Error)

--- a/src/basho_bench_driver_null.erl
+++ b/src/basho_bench_driver_null.erl
@@ -47,5 +47,27 @@ run(an_error, KeyGen, _ValueGen, State) ->
     {error, went_wrong, State};
 run(another_error, KeyGen, _ValueGen, State) ->
     _Key = KeyGen(),
-    {error, {bad, things, happened}, State}.
-
+    {error, {bad, things, happened}, State};
+run(print_key, KeyGen, _ValueGen, State) ->
+    Key = KeyGen(),
+    io:format(user, "~p\n", [Key]),
+    {ok, State};
+run(print_value, _KeyGen, ValueGen, State) ->
+    Value = ValueGen(),
+    io:format(user, "~p\n", [Value]),
+    {ok, State};
+run({print_value, PrintDepth}, _KeyGen, ValueGen, State) ->
+    Value = ValueGen(),
+    io:format(user, "~P\n", [Value, PrintDepth]),
+    {ok, State};
+run(print_key_and_value, KeyGen, ValueGen, State) ->
+    Key = KeyGen(),
+    Value = ValueGen(),
+    io:format(user, "~p ~p\n", [Key, Value]),
+    {ok, State};
+run({print_key_and_value, KeyPrintDepth, ValuePrintDepth}, KeyGen, ValueGen, State) ->
+    Key = KeyGen(),
+    Value = ValueGen(),
+    io:format(user, "~P ~P\n", [Key, KeyPrintDepth,
+                                Value, ValuePrintDepth]),
+    {ok, State}.

--- a/src/basho_bench_keygen.erl
+++ b/src/basho_bench_keygen.erl
@@ -61,6 +61,9 @@ new({bin_to_str, InputGen}, Id) ->
 new({to_binstr, FmtStr, InputGen}, Id) ->
     Gen = new(InputGen, Id),
     fun() -> list_to_binary(io_lib:format(FmtStr, [Gen()])) end;
+new({to_str, FmtStr, InputGen}, Id) ->
+    Gen = new(InputGen, Id),
+    fun() -> lists:flatten(io_lib:format(FmtStr, [Gen()])) end;
 new({base64, InputGen}, Id) ->
     Gen = new(InputGen, Id),
     fun() -> base64:encode(Gen()) end;

--- a/src/basho_bench_keygen.erl
+++ b/src/basho_bench_keygen.erl
@@ -55,6 +55,9 @@ new({{int_to_bin_littleendian, Bits}, InputGen}, Id) ->
 new({int_to_str, InputGen}, Id) ->
     Gen = new(InputGen, Id),
     fun() -> integer_to_list(Gen()) end;
+new({bin_to_str, InputGen}, Id) ->
+    Gen = new(InputGen, Id),
+    fun() -> binary_to_list(Gen()) end;
 new({to_binstr, FmtStr, InputGen}, Id) ->
     Gen = new(InputGen, Id),
     fun() -> list_to_binary(io_lib:format(FmtStr, [Gen()])) end;
@@ -116,6 +119,57 @@ new({function, Module, Function, Args}, Id)
             erlang:apply(Module, Function, [Id] ++ Args);
         _Error ->
             ?FAIL_MSG("Could not find keygen function: ~p:~p\n", [Module, Function])
+    end;
+new({file_line_bin, Path}, Id) ->
+    new({file_line_bin, Path, repeat}, Id);
+new({file_line_bin, Path, DoRepeat}, Id) ->
+    Open = fun() ->
+                   Opts = [read, raw, binary,
+                           {read_ahead, 16*1024*1024}],
+                   {ok, FileH} = file:open(Path, Opts),
+                   FileH
+           end,
+    Loop = fun(L, FH) ->
+                   {Line, FH2}  = case file:read_line(FH) of
+                                      {ok, LineBin} ->
+                                          {LineBin, FH};
+                                      eof when DoRepeat /= repeat ->
+                                          {empty_keygen, FH};
+                                      eof ->
+                                          ?INFO("EOF", []),
+                                          file:close(FH),
+                                          FH_ = Open(),
+                                          {ok, LineBin} = file:read_line(FH_),
+                                          %% Line will always include
+                                          %% the trailing newline.
+                                          WantedLen = byte_size(LineBin) - 1,
+                                          <<Chomped:WantedLen/binary, _/binary>>
+                                              = LineBin,
+                                          {Chomped, FH_}
+                                  end,
+                   receive
+                       {key_req, From} ->
+                           From ! {key_reply, Line}
+                   end,
+                   L(L, FH2)
+           end,
+    if Id == 1 ->
+            spawn(fun() ->
+                          register(file_keygen, self()),
+                          FH = Open(),
+                          Loop(Loop, FH)
+                  end);
+       true ->
+            ok
+    end,
+    fun() ->
+            file_keygen ! {key_req, self()},
+            receive
+                {key_reply, empty_keygen} ->
+                    throw({stop, empty_keygen});
+                {key_reply, Bin} ->
+                    Bin
+            end
     end;
 %% Adapt a value generator. The function keygen would work if Id was added as 
 %% the last parameter. But, alas, it is added as the first.

--- a/src/basho_bench_keygen.erl
+++ b/src/basho_bench_keygen.erl
@@ -180,6 +180,8 @@ new({valgen, ValGen}, Id) ->
     basho_bench_valgen:new(ValGen, Id);
 new(Bin, _Id) when is_binary(Bin) ->
     fun() -> Bin end;
+new(List, _Id) when is_list(List) ->
+    fun() -> List end;
 new(Other, _Id) ->
     ?FAIL_MSG("Invalid key generator requested: ~p\n", [Other]).
 

--- a/src/basho_bench_measurement.erl
+++ b/src/basho_bench_measurement.erl
@@ -50,7 +50,7 @@ run() ->
     gen_server:cast(?MODULE, run).
 
 take_measurement(Measurement) ->
-    gen_server:call(?MODULE, {take_measurement, Measurement}).
+    gen_server:call(?MODULE, {take_measurement, Measurement}, infinity).
 
 %% ====================================================================
 %% gen_server callbacks

--- a/src/basho_bench_stats.erl
+++ b/src/basho_bench_stats.erl
@@ -64,7 +64,7 @@ op_complete(Op, {ok, Units}, ElapsedUs) ->
    % io:format("Get distributed: ~p~n", [get_distributed()]),
     case get_distributed() of
         true ->
-            gen_server:cast({global, ?MODULE}, {Op, {ok, Units}, ElapsedUs}, infinity);
+            gen_server:cast({global, ?MODULE}, {Op, {ok, Units}, ElapsedUs});
         false ->
             folsom_metrics:notify({latencies, Op}, ElapsedUs),
             folsom_metrics:notify({units, Op}, {inc, Units})

--- a/src/basho_bench_stats.erl
+++ b/src/basho_bench_stats.erl
@@ -64,14 +64,14 @@ op_complete(Op, {ok, Units}, ElapsedUs) ->
    % io:format("Get distributed: ~p~n", [get_distributed()]),
     case get_distributed() of
         true ->
-            gen_server:cast({global, ?MODULE}, {Op, {ok, Units}, ElapsedUs});
+            gen_server:cast({global, ?MODULE}, {Op, {ok, Units}, ElapsedUs}, infinity);
         false ->
             folsom_metrics:notify({latencies, Op}, ElapsedUs),
             folsom_metrics:notify({units, Op}, {inc, Units})
     end,
     ok;
 op_complete(Op, Result, ElapsedUs) ->
-    gen_server:call({global, ?MODULE}, {op, Op, Result, ElapsedUs}).
+    gen_server:call({global, ?MODULE}, {op, Op, Result, ElapsedUs}, infinity).
 
 %% ====================================================================
 %% gen_server callbacks

--- a/src/basho_bench_valgen.erl
+++ b/src/basho_bench_valgen.erl
@@ -78,15 +78,22 @@ dimension(_Other, _) ->
 %% Internal Functions
 %% ====================================================================
 
+-define(TAB, valgen_bin_tab).
+
 init_source(Id) ->
     init_source(Id, basho_bench_config:get(?VAL_GEN_BLOB_CFG, undefined)).
 
-init_source(Id, undefined) ->
-    if Id == 1 -> ?DEBUG("random source\n", []);
-       true    -> ok
-    end,
-    SourceSz = basho_bench_config:get(?VAL_GEN_SRC_SIZE, 1048576),
-    {?VAL_GEN_SRC_SIZE, SourceSz, crypto:rand_bytes(SourceSz)};
+init_source(1, undefined) ->
+    SourceSz = basho_bench_config:get(?VAL_GEN_SRC_SIZE, 96*1048576),
+    ?INFO("Random source: calling crypto:rand_bytes(~w) (override with the '~w' config option\n", [SourceSz, ?VAL_GEN_SRC_SIZE]),
+    Bytes = crypto:rand_bytes(SourceSz),
+    ?TAB = ets:new(?TAB, [public, named_table]),
+    true = ets:insert(?TAB, {x, Bytes}),
+    ?INFO("Random source: finished crypto:rand_bytes(~w)\n", [SourceSz]),
+    {?VAL_GEN_SRC_SIZE, SourceSz, Bytes};
+init_source(_Id, undefined) ->
+    [{_, Bytes}] = ets:lookup(?TAB, x),
+    {?VAL_GEN_SRC_SIZE, size(Bytes), Bytes};
 init_source(Id, Path) ->
     {Path, {ok, Bin}} = {Path, file:read_file(Path)},
     if Id == 1 -> ?DEBUG("path source ~p ~p\n", [size(Bin), Path]);

--- a/src/basho_bench_worker.erl
+++ b/src/basho_bench_worker.erl
@@ -53,9 +53,6 @@
 %% ====================================================================
 
 start_link(SupChild, Id) ->
-
-%    {Module, Binary, Filename} = code:get_object_code(basho_bench_worker),
- %   rpc:multicall(nodes(), code, load_binary, [Module, Filename, Binary]).
     case basho_bench_config:get(distribute_work, false) of 
         true -> 
             start_link_distributed(SupChild, Id);

--- a/src/basho_bench_worker.erl
+++ b/src/basho_bench_worker.erl
@@ -68,11 +68,11 @@ start_link_local(SupChild, Id) ->
     gen_server:start_link(?MODULE, [SupChild, Id], []).
 
 run(Pids) ->
-    [ok = gen_server:call(Pid, run) || Pid <- Pids],
+    [ok = gen_server:call(Pid, run, infinity) || Pid <- Pids],
     ok.
 
 stop(Pids) ->
-    [ok = gen_server:call(Pid, stop) || Pid <- Pids],
+    [ok = gen_server:call(Pid, stop, infinity) || Pid <- Pids],
     ok.
 
 %% ====================================================================


### PR DESCRIPTION
I've got a bit of everything here, including:
- gen_server:call() timeout tweaks
- changes to the value generator for sharing a single big block of random data
- add new key generators
- some new commands for the null driver, to aid debugging
- add socket_options to ibrowse (http raw driver)
- additional escript options
