### PR TITLE
Use standard IEC units for KB/s, KiB/s, MB/s, MiB/s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,8 @@ distclean: clean
 results:
 	Rscript --vanilla priv/summary.r -i tests/current
 
+ops_sec-results: results
+
 byte_sec-results:
 	Rscript --vanilla priv/summary.r --ylabel1stgraph byte/sec -i tests/current
 

--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,17 @@ results:
 byte_sec-results:
 	Rscript --vanilla priv/summary.r --ylabel1stgraph byte/sec -i tests/current
 
-kbyte_sec-results:
-	Rscript --vanilla priv/summary.r --ylabel1stgraph Kbyte/sec -i tests/current
+kb_sec-results:
+	Rscript --vanilla priv/summary.r --ylabel1stgraph KB/sec -i tests/current
 
-mbyte_sec-results:
-	Rscript --vanilla priv/summary.r --ylabel1stgraph Mbyte/sec -i tests/current
+kib_sec-results:
+	Rscript --vanilla priv/summary.r --ylabel1stgraph KiB/sec -i tests/current
+
+mb_sec-results:
+	Rscript --vanilla priv/summary.r --ylabel1stgraph MB/sec -i tests/current
+
+mib_sec-results:
+	Rscript --vanilla priv/summary.r --ylabel1stgraph MiB/sec -i tests/current
 
 TARGETS := $(shell ls tests/ | grep -v current)
 JOBS := $(addprefix job,${TARGETS})

--- a/examples/cs.config.sample
+++ b/examples/cs.config.sample
@@ -38,6 +38,8 @@
 {cs_http_proxy_host, [{"localhost", 8080}, {"127.0.0.1", 8080}, {{127,0,0,1}, 8080}]}.
 {cs_http_proxy_port, 8080}.
 {cs_request_timeout, 999999000}.
+% Valid values for cs_measurement_units are ops_sec, byte_sec, kb_sec, 
+% kib_sec, mb_sec, or mib_sec.
 % If using the cs_measurement_units option, you need to change
 % any R graph's labels of the Y axis, e.g. basho_bench's Makefile target
 % "make mb_sec-results"

--- a/examples/cs.config.sample
+++ b/examples/cs.config.sample
@@ -40,8 +40,8 @@
 {cs_request_timeout, 999999000}.
 % If using the cs_measurement_units option, you need to change
 % any R graph's labels of the Y axis, e.g. basho_bench's Makefile target
-% "make mbyte_sec-results"
-{cs_measurement_units, mbyte_sec}.
+% "make mb_sec-results"
+{cs_measurement_units, mb_sec}.
 
 {key_generator, {int_to_str, {partitioned_sequential_int, 1000}}}.
 %{key_generator, {int_to_str, {uniform_int, 1000}}}.

--- a/priv/summary.r
+++ b/priv/summary.r
@@ -36,7 +36,7 @@ if (is.null(opt$width))   { opt$width   = 1280 }
 if (is.null(opt$height))  { opt$height  = 960 }
 if (is.null(opt$indir))   { opt$indir  = "current"}
 if (is.null(opt$outfile)) { opt$outfile = file.path(opt$indir, "summary.png") }
-if (is.null(opt$ylabel1stgraph)) { opt$ylabel1stgraph = "Op/sec" }
+if (is.null(opt$ylabel1stgraph)) { opt$ylabel1stgraph = "Ops/sec" }
 if (is.null(opt$title)) { opt$title = "Throughput" }
 
 # Load the benchmark data, passing the time-index range we're interested in

--- a/src/basho_bench_driver_cs.erl
+++ b/src/basho_bench_driver_cs.erl
@@ -61,15 +61,19 @@ new(ID) ->
     Disconnect = basho_bench_config:get(cs_disconnect_frequency, infinity),
     erlang:put(disconnect_freq, Disconnect),
 
-    %% Get our measurement units: op/sec, Byte/sec, KByte/sec, MByte/sec
+    %% Get our measurement units: ops/sec, Byte/sec, KB/sec, KiB/sec, MB/sec, MiB/sec.
+    %% Throw a run-time exception if the config file has cs_measurement_units set 
+    %% to an unrecognized value.
     {RF_name, ReportFun} =
-        %% We need to be really careful with these custom units things.
-        %% Use floats for everything.
+        %% Use standard IEC units for KB/s, KiB/s, MB/s, MiB/s.
+        %% See http://en.wikipedia.org/wiki/Mebibyte for more information.
         case (catch basho_bench_config:get(cs_measurement_units)) of
-            N = byte_sec  -> {N,      fun(X) -> X / 1 end};
-            N = kbyte_sec -> {N,      fun(X) -> X / 1024 end};
-            N = mbyte_sec -> {N,      fun(X) -> X / (1024 * 1024) end};
-            _             -> {op_sec, fun(_) -> 1.0 end}
+            N = ops_sec  -> {N, fun(X) -> 1.0 end};
+            N = byte_sec -> {N, fun(X) -> X / 1 end};
+            N = kb_sec   -> {N, fun(X) -> X / 1000 end};
+            N = kib_sec  -> {N, fun(X) -> X / 1024 end};
+            N = mb_sec   -> {N, fun(X) -> X / (1000 * 1000) end};
+            N = mib_sec  -> {N, fun(X) -> X / (1024 * 1024) end};
         end,
     if ID == 1 ->
             application:start(ibrowse),


### PR DESCRIPTION
When testing RiakCS using Basho Bench the results generated by src/basho_bench_driver_cs.erl and graphed by R use kebibytes/sec and mebibytes/sec but reported the results in kilobytes/sec and megabytes/sec. I fixed the units so that you now get and graph the units that you specify: ops_sec, byte_sec, kb_sec, kib_sec, mb_sec, or mib_sec. (See http://en.wikipedia.org/wiki/Mebibyte for more information.)

Also, if someone used an unknown value or made a typo when entering cs_measurement_units the units would  default to ops_sec. I fixed this so that you now have to specify ops_sec if you want ops_sec, and an unknown value throws an error and stops.