### PR TITLE
Use include_lib instead of hardcoding paths

### DIFF
--- a/src/basho_bench_driver_cassandra_cql.erl
+++ b/src/basho_bench_driver_cassandra_cql.erl
@@ -26,7 +26,7 @@
          run/4]).
 
 -include("basho_bench.hrl").
--include("deps/cqerl/include/cqerl.hrl").
+-include_lib("cqerl/include/cqerl.hrl").
 
 -record(state, { client,
                  keyspace,


### PR DESCRIPTION
This simple change makes it possible to use basho_bench as a dependency of other applications.