### PR TITLE
Manually adding meck to rebar.config to fix a dependency mismatch

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,6 +9,7 @@
   %%       increments.  If someone wants to take advantage of a
   %%       new folsom feature, that desire + float incr must be
   %%       weighed.
+  {meck,"0.8.2",{git,"git://github.com/eproxus/meck",{tag, "0.8.2"}}},
   {node_package, "2.0.*", {git, "git://github.com/basho/node_package", {tag, "2.0.0"}}},
   {folsom, ".*", {git, "git://github.com/basho/folsom.git", {branch, "boundary-0.7.1+basho-bench-float"}}},
   {lager, "2.*", {git, "git://github.com/basho/lager", {tag, "2.1.0"}}},


### PR DESCRIPTION
Master currently shows the following on `make`

```
Cloning into 'protobuffs'...
WARN:  /Users/dkerrigan/src/basho/basho_bench/deps/meck/src/meck.app.src has version "0.8.3"; requested regex was 0.8.2
WARN:  Missing plugins: [rebar_lock_deps_plugin]
==> protobuffs (get-deps)
WARN:  /Users/dkerrigan/src/basho/basho_bench/deps/meck/src/meck.app.src has version "0.8.3"; requested regex was 0.8.2
WARN:  /Users/dkerrigan/src/basho/basho_bench/deps/meck/src/meck.app.src has version "0.8.3"; requested regex was 0.8.2
ERROR: Dependency dir /Users/dkerrigan/src/basho/basho_bench/deps/meck failed application validation with reason:
{version_mismatch,{"/Users/dkerrigan/src/basho/basho_bench/deps/meck/src/meck.app.src",
                   {expected,"0.8.2"},
                   {has,"0.8.3"}}}.
ERROR: 'get-deps' failed while processing /Users/dkerrigan/src/basho/basho_bench/deps/protobuffs: rebar_abort
make: *** [deps] Error 1
```
