### PR TITLE
Allow compilation with OTP R18

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 %% katja: Defines a function `query()`, which is a reserved word in R15
 %% uuid: Dep on quickrand
 %% quickrand: Bogus (IMHO) inability to adapt to R15 environment.
-{require_otp_vsn, "R16|17"}.
+{require_otp_vsn, "R16|17|18"}.
 
 {deps,
  [


### PR DESCRIPTION
I'm using R18 for running basho_bench_driver_http load testing and haven't seen any problems.