### PR TITLE
Lock riakc version just like riak_test

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -21,7 +21,7 @@
   {ibrowse, ".*",
    {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.0.2"}}},
   {riakc, ".*",
-   {git, "git://github.com/basho/riak-erlang-client", {branch, "master"}}},
+   {git, "git://github.com/basho/riak-erlang-client", {tag, "2.1.2"}}},
   {mochiweb, "2.9.*",
    {git, "git://github.com/basho/mochiweb", {tag, "v2.9.0"}}},
   {getopt, ".*",


### PR DESCRIPTION
I'm not sure that putting this in master is the right thing to do, since I don't completely understand how this will affect testing of older versions of riak, ie 2.0.next. Since we were always pulling in the latest version of the client anyway, that may not matter, but we should at least think about it.