### PR TITLE
Removed period in front of $REBAR in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ all: deps compile
 .PHONY: deps compile rel lock locked-all locked-deps
 
 rel: deps compile
-	cd rel && .$(REBAR) generate skip_deps=true $(OVERLAY_VARS)
+	cd rel && $(REBAR) generate skip_deps=true $(OVERLAY_VARS)
 
 deps:
 	$(REBAR) get-deps


### PR DESCRIPTION
Unnecessary and causes a "No such file or directory" error when building a rel.