### PR TITLE
Fixes bug that prevents the use of custom key and value generators

### DIFF
--- a/src/basho_bench_keygen.erl
+++ b/src/basho_bench_keygen.erl
@@ -122,7 +122,7 @@ new({function, Module, Function, Args}, Id)
   when is_atom(Module), is_atom(Function), is_list(Args) ->
     case code:ensure_loaded(Module) of
         {module, Module} ->
-            erlang:apply(Module, Function, [Id] ++ Args);
+            fun() -> erlang:apply(Module, Function, [Id] ++ Args) end;
         _Error ->
             ?FAIL_MSG("Could not find keygen function: ~p:~p\n", [Module, Function])
     end;

--- a/src/basho_bench_valgen.erl
+++ b/src/basho_bench_valgen.erl
@@ -54,7 +54,7 @@ new({function, Module, Function, Args}, Id)
   when is_atom(Module), is_atom(Function), is_list(Args) ->
     case code:ensure_loaded(Module) of
         {module, Module} ->
-            erlang:apply(Module, Function, [Id] ++ Args);
+            fun() -> erlang:apply(Module, Function, [Id] ++ Args) end;
         _Error ->
             ?FAIL_MSG("Could not find valgen function: ~p:~p\n", [Module, Function])
     end;


### PR DESCRIPTION
The function new/2 in both basho_bench_keygen and basho_bench_valgen is
expected to return a function.

But if the generator provided is of type {function, Module, Function,
Args} the new/2 function returns, instead of a function, the key or the
value itself.

This PR fixes this problem by wrapping the erlang:apply call in a
function so that the new/2 function returns a function instead of a
value.