### PR TITLE
Mas i371 reducejsondecode

### DIFF
--- a/src/basho_bench_driver_nhs.erl
+++ b/src/basho_bench_driver_nhs.erl
@@ -40,17 +40,15 @@
                 pb_timeout,
                 http_timeout,
                 fold_timeout,
-                alwaysget_perworker_maxkeycount = 1 :: integer(),
-                alwaysget_perworker_minkeycount = 1 :: integer(),
+                alwaysget_perworker_maxkeycount = 1 :: pos_integer(),
+                alwaysget_perworker_minkeycount = 1 :: pos_integer(),
                 alwaysget_keyorder :: key_order|skew_order,
-                unique_size :: integer(),
+                unique_size :: pos_integer(),
                 unique_keyorder :: key_order|skew_order,
                 postcode_indexcount = 3 :: pos_integer(),
-                postcodeq_count = 0 :: integer(),
-                postcodeq_sum = 0 :: integer(),
-                dobq_count = 0 :: integer(),
-                dobq_sum = 0 :: integer(),
-                query_logfreq :: integer(),
+                postcodeq_count = 0 :: non_neg_integer(),
+                dobq_count = 0 :: non_neg_integer(),
+                query_logfreq :: pos_integer(),
                 nominated_id :: boolean(),
                 % ID 1 is nominated to do special work
                 singleton_pid :: pid() | undefined,
@@ -556,22 +554,20 @@ run(postcodequery_http, _KeyGen, _ValueGen, State) ->
     URL = io_lib:format("http://~s:~p/buckets/~s/index/postcode_bin/~s/~s",
                     [Host, Port, Bucket, StartKey, EndKey]),
 
-    case json_get(URL, State#state.http_timeout) of
-        {ok, {struct, Proplist}} ->
-            Results = proplists:get_value(<<"keys">>, Proplist),
+    case jsonb_pool_get(URL, State#state.http_timeout) of
+        {ok, JsonB} ->
             C0 = State#state.postcodeq_count,
-            S0 = State#state.postcodeq_sum,
-            {C1, S1} = 
-                case {C0, C0 rem State#state.query_logfreq} of 
-                    {C0, 0} when C0 > 0 ->
-                        Avg = float_to_list(S0 / C0, [{decimals, 3}]),
-                        lager:info("Average postcode query result size of ~s",
-                                    [Avg]),
-                        {1, length(Results)};
-                    _ ->
-                        {C0 + 1, S0 + length(Results)}
-                end,
-            {ok, State#state{postcodeq_count = C1, postcodeq_sum = S1}};
+            case C0 rem State#state.query_logfreq of 
+                0 ->
+                    {struct, Proplist} = mochijson2:decode(JsonB),
+                    Results = proplists:get_value(<<"keys">>, Proplist),
+                    lager:info(
+                        "postcode query result size of ~w",
+                        [length(Results)]);
+                _ ->
+                    ok
+            end,
+            {ok, State#state{postcodeq_count = C0 + 1}};
         {error, Reason} ->
             io:format("[~s:~p] ERROR - Reason: ~p~n",
                         [?MODULE, ?LINE, Reason]),
@@ -595,27 +591,25 @@ run(dobquery_http, _KeyGen, _ValueGen, State) ->
     URL = io_lib:format(URLSrc, 
                         [Host, Port, Bucket, DoBStart, DoBEnd, RE]),
 
-    case json_get(URL, State#state.http_timeout) of
-        {ok, {struct, Proplist}} ->
-            Results = proplists:get_value(<<"keys">>, Proplist),
+    case jsonb_pool_get(URL, State#state.http_timeout) of
+        {ok, JsonB} ->
             C0 = State#state.dobq_count,
-            S0 = State#state.dobq_sum,
-            {C1, S1} = 
-                case {C0, C0 rem State#state.query_logfreq} of 
-                    {C0, 0} when C0 > 0 ->
-                        Avg = float_to_list(S0 / C0, [{decimals, 3}]),
-                        lager:info("Average dob query result size of ~s",
-                                    [Avg]),
-                        {1, length(Results)};
-                    _ ->
-                        {C0 + 1, S0 + length(Results)}
-                end,
-            {ok, State#state{dobq_count = C1, dobq_sum = S1}};
+            case C0 rem State#state.query_logfreq of 
+                0 ->
+                    {struct, Proplist} = mochijson2:decode(JsonB),
+                    Results = proplists:get_value(<<"keys">>, Proplist),
+                    lager:info(
+                        "dob query result size of ~w",
+                        [length(Results)]);
+                _ ->
+                    ok
+            end,
+            {ok, State#state{dobq_count = C0 + 1}};
         {error, Reason} ->
             io:format("[~s:~p] ERROR - Reason: ~p~n",
                         [?MODULE, ?LINE, Reason]),
             {error, Reason, State}
-    end;
+        end;
 
 run(aae_query, _KeyGen, _ValueGen, State) ->
     IsAlive =
@@ -728,19 +722,20 @@ prepare_unique_put(State) ->
     Robj2 = riakc_obj:update_metadata(Robj1, MD2),
     {Pid, Bucket, Key, Robj2, UKC}.
 
-json_get(Url, Timeout) ->
-    json_get(Url, Timeout, true).
-
-json_get(Url, Timeout, UsePool) ->
+jsonb_pool_get(Url, Timeout) ->
     Target = lists:flatten(Url),
-    Response = 
-        case UsePool of 
-            true ->
-                ibrowse:send_req(Target, [], get, [], [], Timeout);
-            false ->
-                {ok, C} = ibrowse:spawn_worker_process(Target),
-                ibrowse:send_req_direct(C, Target, [], get, [], [], Timeout)
-        end,
+    Response = ibrowse:send_req(Target, [], get, [], [], Timeout),
+    case Response of
+        {ok, "200", _, Body} ->
+            {ok, Body};
+        Other ->
+            {error, Other}
+    end.
+
+json_direct_get(Url, Timeout) ->
+    Target = lists:flatten(Url),
+    {ok, C} = ibrowse:spawn_worker_process(Target),
+    Response = ibrowse:send_req_direct(C, Target, [], get, [], [], Timeout),
     case Response of
         {ok, "200", _, Body} ->
             {ok, mochijson2:decode(Body)};
@@ -807,7 +802,7 @@ run_aaequery(State) ->
     URL = io_lib:format(URLSrc, 
                         [Host, Port, Bucket, KeyStart, KeyEnd, MapFoldMod]),
     
-    case json_get(URL, State#state.fold_timeout, false) of
+    case json_direct_get(URL, State#state.fold_timeout) of
         {ok, {struct, TreeL}} ->
             {<<"count">>, Count} = lists:keyfind(<<"count">>, 1, TreeL),
             lager:info("AAE query returned in ~w seconds covering ~s keys",
@@ -833,7 +828,7 @@ run_listkeys(State) ->
     URL = io_lib:format(URLSrc, 
                         [Host, Port, Bucket]),
     
-    case json_get(URL, State#state.fold_timeout, false) of
+    case json_direct_get(URL, State#state.fold_timeout) of
         {ok, {struct, [{<<"keys">>, KeyList}]}} ->
             lager:info("List keys returned ~w keys in ~w seconds",
                       [length(KeyList), 
@@ -874,7 +869,7 @@ run_segmentfold(State) ->
                         [Host, Port, Bucket, KeyStart, KeyEnd, 
                             MapFoldMod, MapFoldOpts]),
     
-    case json_get(URL, State#state.fold_timeout, false) of
+    case json_direct_get(URL, State#state.fold_timeout) of
         {ok, {struct, [{<<"deltas">>, SegL}]}} ->
             lager:info("Segment fold returned in ~w seconds finding ~w keys",
                       [timer:now_diff(os:timestamp(), SW)/1000000, length(SegL)]),

--- a/src/basho_bench_driver_nhs.erl
+++ b/src/basho_bench_driver_nhs.erl
@@ -30,6 +30,9 @@
 
 -include("basho_bench.hrl").
 
+-define(QUERYLOG_FREQ, 2000).
+-define(FORCEAAE_FREQ, 10). % Every 10 seconds
+
 -record(state, {
                 pb_pid,
                 repl_pid,
@@ -46,8 +49,10 @@
                 unique_size :: pos_integer(),
                 unique_keyorder :: key_order|skew_order,
                 postcode_indexcount = 3 :: pos_integer(),
-                postcodeq_count = 0 :: non_neg_integer(),
-                dobq_count = 0 :: non_neg_integer(),
+                postcodeq_count = rand:uniform(?QUERYLOG_FREQ)
+                    :: non_neg_integer(),
+                dobq_count = rand:uniform(?QUERYLOG_FREQ)
+                    :: non_neg_integer(),
                 query_logfreq :: pos_integer(),
                 nominated_id :: boolean(),
                 % ID 1 is nominated to do special work
@@ -59,8 +64,6 @@
                 last_forceaae = os:timestamp() :: erlang:timestamp()
          }).
 
--define(QUERYLOG_FREQ, 10000).
--define(FORCEAAE_FREQ, 10). % Every 10 seconds
 
 -define(POSTCODE_AREAS,
                 [{1, "AB"}, {2, "AL"}, {3, "B"}, {4, "BA"}, {5, "BB"}, 
@@ -229,7 +232,7 @@ new(Id) ->
                pb_timeout = PBTimeout,
                http_timeout = HTTPTimeout,
                fold_timeout = FoldTimeout,
-               query_logfreq = rand:uniform(?QUERYLOG_FREQ),
+               query_logfreq = ?QUERYLOG_FREQ,
                nominated_id = NominatedID,
                unique_key_count = 1,
                alwaysget_key_count = 0,


### PR DESCRIPTION
Reduce the CPU load in running 2i tests, by not decoding them all.  Also takes the decode time away from the performance measure