### PR TITLE
Start ssl when using secure connection with riakc_pb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,12 @@ PKG_ID           = basho-bench-$(PKG_VERSION)
 PKG_BUILD        = 1
 BASE_DIR         = $(shell pwd)
 ERLANG_BIN       = $(shell dirname $(shell which erl))
-REBAR           ?= $(BASE_DIR)/rebar
+REBAR           ?= $(BASE_DIR)/rebar3
 OVERLAY_VARS    ?=
 
 
 all: deps compile
-	$(REBAR) skip_deps=true escriptize
+	$(REBAR) escriptize
 
 .PHONY: deps compile rel lock locked-all locked-deps
 

--- a/src/basho_bench_driver_riakc_pb.erl
+++ b/src/basho_bench_driver_riakc_pb.erl
@@ -128,7 +128,13 @@ new(Id) ->
     Targets = basho_bench_config:normalize_ips(Ips, Port),
     {TargetIp, TargetPort} = lists:nth((Id rem length(Targets)+1), Targets),
     ?INFO("Using target ~p:~p for worker ~p\n", [TargetIp, TargetPort, Id]),
-    case riakc_pb_socket:start_link(TargetIp, TargetPort, get_connect_options()) of
+
+    Options = get_connect_options(),
+    case proplists:is_defined(cacertfile, Options) of
+      true -> ssl:start();
+      _ -> ok
+    end,
+    case riakc_pb_socket:start_link(TargetIp, TargetPort, Options) of
         {ok, Pid} ->
             NominatedID = Id == 1,
             {ok, #state { pid = Pid,


### PR DESCRIPTION
With a secure PB connection, ssl had to be started. 